### PR TITLE
Add CPACK_RPM_PACKAGE_AUTOREQPROV

### DIFF
--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -35,6 +35,7 @@ macro(rocm_create_package)
     set(CPACK_NSIS_PACKAGE_NAME ${PARSE_NAME})
 
     set(CPACK_RPM_PACKAGE_RELOCATABLE Off)
+    set( CPACK_RPM_PACKAGE_AUTOREQPROV Off CACHE BOOL "turns off rpm autoreqprov field; packages explicity list dependencies" )
 
     set(CPACK_GENERATOR "TGZ;ZIP")
     if(EXISTS ${MAKE_NSIS_EXE})


### PR DESCRIPTION
Adding this CMAKE field so that dependencies are not automatically pulled in by RPMbuild.  Packages must explicit state their own dependencies (lower level rpm's are not accurately filling out their PROVIDES field).