### PR TITLE
Adding support for inl packaging for rocThrust 

### DIFF
--- a/share/rocm/cmake/ROCMInstallTargets.cmake
+++ b/share/rocm/cmake/ROCMInstallTargets.cmake
@@ -49,7 +49,7 @@ function(rocm_install_targets)
             PATTERN "*.hpp"
             PATTERN "*.hh"
             PATTERN "*.hxx"
-	    PATTERN "*.inl"
+            PATTERN "*.inl"
         )
     endforeach()
 

--- a/share/rocm/cmake/ROCMInstallTargets.cmake
+++ b/share/rocm/cmake/ROCMInstallTargets.cmake
@@ -49,6 +49,7 @@ function(rocm_install_targets)
             PATTERN "*.hpp"
             PATTERN "*.hh"
             PATTERN "*.hxx"
+	    PATTERN "*.inl"
         )
     endforeach()
 


### PR DESCRIPTION
inl files are used in rocThrust and need to be packaged for this header only library. 