### PR TITLE
softlink directory

### DIFF
--- a/share/rocm/cmake/ROCMInstallSymlinks.cmake
+++ b/share/rocm/cmake/ROCMInstallSymlinks.cmake
@@ -3,7 +3,7 @@
 ################################################################################
 
 
-function(rocm_install_symlink_subdir SUBDIR)
+function(rocm_install_symlink_subdir SUBDIR CUSTOM_DIRECTORY)
     # TODO: Check if SUBDIR is relative path
     # Copy instead of symlink on windows
     if(CMAKE_HOST_WIN32)
@@ -16,7 +16,7 @@ function(rocm_install_symlink_subdir SUBDIR)
         file(GLOB_RECURSE FILES RELATIVE \${SUBDIR} \${SUBDIR}/*)
         foreach(FILE \${FILES})
             set(SRC \${SUBDIR}/\${FILE})
-            set(DEST \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/\${FILE})
+            set(DEST \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/$CUSTOM_DIRECTORY\${FILE})
             get_filename_component(DEST_DIR \${DEST} DIRECTORY)
             file(MAKE_DIRECTORY \${DEST_DIR})
             file(RELATIVE_PATH SRC_REL \${DEST_DIR} \${SRC})


### PR DESCRIPTION
I need to install the soft links in a custom directory in CMAKE_INSTALL_PREFIX. What do you propose is the best way to do this? This PR contains untested suggestion. The goal is for a library to install softlinks to files in /opt/rocm/$library/include* to /opt/rocm/include/$library. Now by default the softlinks go to /opt/rocm/include/
If there is another way to do it, that will be great.