### PR TITLE
rocm_set_soversion added 

### DIFF
--- a/share/rocm/cmake/ROCMSetupVersion.cmake
+++ b/share/rocm/cmake/ROCMSetupVersion.cmake
@@ -158,6 +158,8 @@ endfunction()
 function(rocm_set_soversion)
     set(oneValueArgs TARGET SOVERSION)
 
-    rocm_version_regex_parse("^([0-9]+).*" SOVERSION_MAJOR "${SOVERSION}")
-    set_target_properties(TARGET PROPERTIES VERSION ${SOVERSION_MAJOR} SOVERSION ${SOVERSION})
+    cmake_parse_arguments(PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    rocm_version_regex_parse("^([0-9]+).*" SOVERSION_MAJOR "${PARSE_SOVERSION}")
+    set_target_properties(${PARSE_TARGET} PROPERTIES VERSION ${SOVERSION_MAJOR} SOVERSION ${PARSE_SOVERSION})
 endfunction()

--- a/share/rocm/cmake/ROCMSetupVersion.cmake
+++ b/share/rocm/cmake/ROCMSetupVersion.cmake
@@ -154,3 +154,10 @@ function(rocm_setup_version)
     endif()
 
 endfunction()
+
+function(rocm_set_soversion)
+    set(oneValueArgs TARGET SOVERSION)
+
+    rocm_version_regex_parse("^([0-9]+).*" SOVERSION_MAJOR "${SOVERSION}")
+    set_target_properties(${TARGET} PROPERTIES VERSION ${SOVERSION_MAJOR} SOVERSION ${SOVERSION})
+endfunction()

--- a/share/rocm/cmake/ROCMSetupVersion.cmake
+++ b/share/rocm/cmake/ROCMSetupVersion.cmake
@@ -159,5 +159,5 @@ function(rocm_set_soversion)
     set(oneValueArgs TARGET SOVERSION)
 
     rocm_version_regex_parse("^([0-9]+).*" SOVERSION_MAJOR "${SOVERSION}")
-    set_target_properties(${TARGET} PROPERTIES VERSION ${SOVERSION_MAJOR} SOVERSION ${SOVERSION})
+    set_target_properties(TARGET PROPERTIES VERSION ${SOVERSION_MAJOR} SOVERSION ${SOVERSION})
 endfunction()

--- a/share/rocm/cmake/ROCMSetupVersion.cmake
+++ b/share/rocm/cmake/ROCMSetupVersion.cmake
@@ -155,11 +155,7 @@ function(rocm_setup_version)
 
 endfunction()
 
-function(rocm_set_soversion)
-    set(oneValueArgs LIBRARY_TARGET SOVERSION)
-
-    cmake_parse_arguments(PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-    rocm_version_regex_parse("^([0-9]+).*" SOVERSION_MAJOR "${PARSE_SOVERSION}")
-    set_target_properties(${PARSE_LIBRARY_TARGET} PROPERTIES VERSION ${SOVERSION_MAJOR} SOVERSION ${PARSE_SOVERSION})
+function(rocm_set_soversion LIBRARY_TARGET SOVERSION)
+    rocm_version_regex_parse("^([0-9]+).*" SOVERSION_MAJOR "${SOVERSION}")
+    set_target_properties(${LIBRARY_TARGET} PROPERTIES VERSION ${SOVERSION_MAJOR} SOVERSION ${SOVERSION})
 endfunction()

--- a/share/rocm/cmake/ROCMSetupVersion.cmake
+++ b/share/rocm/cmake/ROCMSetupVersion.cmake
@@ -156,10 +156,10 @@ function(rocm_setup_version)
 endfunction()
 
 function(rocm_set_soversion)
-    set(oneValueArgs TARGET SOVERSION)
+    set(oneValueArgs LIBRARY_TARGET SOVERSION)
 
     cmake_parse_arguments(PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     rocm_version_regex_parse("^([0-9]+).*" SOVERSION_MAJOR "${PARSE_SOVERSION}")
-    set_target_properties(${PARSE_TARGET} PROPERTIES VERSION ${SOVERSION_MAJOR} SOVERSION ${PARSE_SOVERSION})
+    set_target_properties(${PARSE_LIBRARY_TARGET} PROPERTIES VERSION ${SOVERSION_MAJOR} SOVERSION ${PARSE_SOVERSION})
 endfunction()


### PR DESCRIPTION
Usable by math libraries to manage the ABI version MAJOR parsing.