### PR TITLE
Print WARNING instead of ERROR for modified toolchain variables

### DIFF
--- a/share/rocm/cmake/ROCMChecks.cmake
+++ b/share/rocm/cmake/ROCMChecks.cmake
@@ -16,7 +16,7 @@ function(rocm_check_toolchain_var var access value)
     if(access STREQUAL "MODIFIED_ACCESS")
         message("
 *******************************************************************************
-*----------------------------------- ERROR -----------------------------------*
+*---------------------------------- WARNING ----------------------------------*
 * The variable '${var}' should only be set by the cmake toolchain,
 * either by calling 'cmake -D${var}=\"${value}\"' or
 * set in a toolchain file and added with 


### PR DESCRIPTION
Modified toolchain variables should print a `WARNING`, not an `ERROR`, since they are non-fatal, and since several projects have legacy CMake code which modifies toolchain variables, and which are unlikely to be fixed soon.

Printing `ERROR` makes it hard to find real errors in builds, such as by searching for "error" strings in logs.

The warnings can continue to be loud and prominent, in order to encourage the fixing of legacy code which violates toolchain conventions.

@amcamd @saadrahim @amdkila @TorreZuk @eidenyoshida @bragadeesh @sdquiring @zaliu