### PR TITLE
Add clang tidy target to check all sources related to the original target

### DIFF
--- a/share/rocm/cmake/ROCMClangTidy.cmake
+++ b/share/rocm/cmake/ROCMClangTidy.cmake
@@ -142,6 +142,7 @@ function(rocm_clang_tidy_check TARGET)
     # TODO: Use generator expressions instead
     # COMMAND ${CLANG_TIDY_COMMAND} $<TARGET_PROPERTY:${TARGET},SOURCES>
     # COMMAND ${CLANG_TIDY_COMMAND} $<JOIN:$<TARGET_PROPERTY:${TARGET},SOURCES>, >
+    add_custom_target(tidy-target-${TARGET})
     foreach(SOURCE ${SOURCES})
         if(NOT "${SOURCE}" MATCHES "(h|hpp|hxx)$")
             string(MAKE_C_IDENTIFIER "${SOURCE}" tidy_file)        
@@ -153,6 +154,7 @@ function(rocm_clang_tidy_check TARGET)
             )
             add_dependencies(${tidy_target} ${TARGET})
             add_dependencies(${tidy_target} tidy-base)
+            add_dependencies(tidy-target-${TARGET} ${tidy_target})
             add_dependencies(tidy ${tidy_target})
         endif()
     endforeach()


### PR DESCRIPTION
This provides a missing middle-ground between running clang-tidy on the entire project, and running clang-tidy on individual source files.