### PR TITLE
Adding libpatch version to VERSION for uniform package naming structure

### DIFF
--- a/share/rocm/cmake/ROCMSetupVersion.cmake
+++ b/share/rocm/cmake/ROCMSetupVersion.cmake
@@ -131,6 +131,8 @@ function(rocm_setup_version)
         # Compensate for missing patch version
         if(PARSE_VERSION MATCHES "^[0-9]+\\.[0-9]+$")
             set(PARSE_VERSION ${PARSE_VERSION}.0)
+            #SWDEV-234857 : new nomanclature:Version=Major.minor.patch.<libpatch>
+            set(PARSE_VERSION ${PARSE_VERSION}.$ENV{ROCM_LIBPATCH_VERSION})
         endif()
         if(PARSE_NO_GIT_TAG_VERSION)
             set(PACKAGE_VERSION ${PARSE_VERSION})


### PR DESCRIPTION
As per new naming standard :
Version=Major.minor.patch.<libpatch>

This change aims to execute the same.