### PR TITLE
Add option to disable ROCM Toolchain check completely

### DIFF
--- a/share/rocm/cmake/ROCMChecks.cmake
+++ b/share/rocm/cmake/ROCMChecks.cmake
@@ -8,6 +8,9 @@ set(ROCM_WARN_TOOLCHAIN_VAR
 set(ROCM_ERROR_TOOLCHAIN_VAR
     OFF
     CACHE BOOL "")
+set(ROCM_CHECK_TOOLCHAIN_VAR
+    ON
+    CACHE BOOL "")
 
 function(rocm_check_toolchain_var var access value list_file)
     set(message_type STATUS)
@@ -26,7 +29,7 @@ function(rocm_check_toolchain_var var access value list_file)
         elseif("${base}" MATCHES ".*/CMakeFiles/${CMAKE_VERSION}$")
             set(cmake_module On)
         endif()
-        if(NOT cmake_module)
+        if(NOT cmake_module AND ROCM_CHECK_TOOLCHAIN_VAR)
             message(
                 "
 *******************************************************************************

--- a/share/rocm/cmake/ROCMChecks.cmake
+++ b/share/rocm/cmake/ROCMChecks.cmake
@@ -13,25 +13,26 @@ set(ROCM_CHECK_TOOLCHAIN_VAR
     CACHE BOOL "")
 
 function(rocm_check_toolchain_var var access value list_file)
-    set(message_type STATUS)
-    if(ROCM_WARN_TOOLCHAIN_VAR)
-        set(message_type WARNING)
-    endif()
-    if(ROCM_ERROR_TOOLCHAIN_VAR)
-        set(message_type SEND_ERROR)
-    endif()
-    if(access STREQUAL "MODIFIED_ACCESS")
-        set(cmake_module Off)
-        get_filename_component(base "${list_file}" DIRECTORY)
-        # Skip warning in cmake's built-in modules
-        if("${base}" STREQUAL "${CMAKE_ROOT}/Modules")
-            set(cmake_module On)
-        elseif("${base}" MATCHES ".*/CMakeFiles/${CMAKE_VERSION}$")
-            set(cmake_module On)
+    if (ROCM_CHECK_TOOLCHAIN_VAR)
+        set(message_type STATUS)
+        if(ROCM_WARN_TOOLCHAIN_VAR)
+            set(message_type WARNING)
         endif()
-        if(NOT cmake_module AND ROCM_CHECK_TOOLCHAIN_VAR)
-            message(
-                "
+        if(ROCM_ERROR_TOOLCHAIN_VAR)
+            set(message_type SEND_ERROR)
+        endif()
+        if(access STREQUAL "MODIFIED_ACCESS")
+            set(cmake_module Off)
+            get_filename_component(base "${list_file}" DIRECTORY)
+            # Skip warning in cmake's built-in modules
+            if("${base}" STREQUAL "${CMAKE_ROOT}/Modules")
+                set(cmake_module On)
+            elseif("${base}" MATCHES ".*/CMakeFiles/${CMAKE_VERSION}$")
+                set(cmake_module On)
+            endif()
+            if(NOT cmake_module)
+                message(
+                    "
 *******************************************************************************
 *----------------------------------- ERROR -----------------------------------*
 * The variable '${var}' should only be set by the cmake toolchain,
@@ -41,7 +42,8 @@ function(rocm_check_toolchain_var var access value list_file)
 *-----------------------------------------------------------------------------*
 *******************************************************************************
 ")
-            message(${message_type} "The toolchain variable '${var}' is modified in the CMakeLists.txt.")
+                message(${message_type} "The toolchain variable '${var}' is modified in the CMakeLists.txt.")
+            endif()
         endif()
     endif()
 endfunction()


### PR DESCRIPTION
By default ROCm CMake will always print a message when a toolchain variable was modified, even if the warning and the error were switched off explicitly. This adds another switch to disable the message completely.