### PR TITLE
Add rocm_check_target_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,15 @@ rocm_setup_version
     )
 
 Setup the version for the project. This will try to use git tag to set the version if possible unless `NO_GIT_TAG_VERSION` is passed. The `PARENT` argument can be used to set the commit to start the count of number of commits to the current revision.
+
+ROCMCheckTargetIds
+==================
+
+rocm_check_target_ids
+---------------------
+
+    rocm_check_target_ids(<output-variable>
+        TARGETS <target-id>...
+    )
+
+Returns the subset of HIP [target-ids](https://clang.llvm.org/docs/ClangOffloadBundler.html#target-id) supported by the current CXX compiler.

--- a/share/rocm/cmake/ROCMCheckTargetIds.cmake
+++ b/share/rocm/cmake/ROCMCheckTargetIds.cmake
@@ -1,0 +1,29 @@
+# ######################################################################################################################
+# Copyright (C) 2021 Advanced Micro Devices, Inc.
+# ######################################################################################################################
+
+include(CheckCXXCompilerFlag)
+include(CMakeParseArguments)
+
+function(rocm_check_target_ids VARIABLE)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs TARGETS)
+
+    cmake_parse_arguments(PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(PARSE_UNPARSED_ARGUMENTS)
+        message(
+            FATAL_ERROR
+                "Unknown keywords given to rocm_check_target_ids(): \"${PARSE_UNPARSED_ARGUMENTS}\"")
+    endif()
+
+    foreach(_target_id ${PARSE_TARGETS})
+        set(_result_var "HAVE_${_target_id}")
+        check_cxx_compiler_flag("-xhip --offload-arch=${_target_id}" "${_result_var}")
+        if(${_result_var})
+            list(APPEND _supported_target_ids "${_target_id}")
+        endif()
+    endforeach()
+    set(${VARIABLE} "${_supported_target_ids}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
I've added a function that will check if the given list of target-ids are supported by the current CXX compiler, and return the subset that are.