### PR TITLE
Generate version file for cmake versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log for rocm-cmake
 
 
+## [0.5.1]
+### Added
+    - Add ROCMConfigVersion.cmake file so cmake can check the version
+
 ## [0.5]
 ### Added
     - Change Log added and version number incremented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [0.5.1]
 ### Added
     - Add ROCMConfigVersion.cmake file so cmake can check the version
+    - Switched to semantic versioning
 
 ## [0.5]
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,17 @@ set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "")
 project(rocm-cmake)
 
 install(DIRECTORY share DESTINATION .)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ROCMConfigVersion.cmake DESTINATION share/rocm/cmake)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/share/rocm/cmake)
 include(ROCMCreatePackage)
 include(ROCMSetupVersion)
 
 rocm_setup_version(VERSION 0.5)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ROCMConfigVersion.cmake
+    COMPATIBILITY SameMinorVersion)
 
 rocm_create_package(
     NAME rocm-cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/share/rocm/cmake)
 include(ROCMCreatePackage)
 include(ROCMSetupVersion)
 
-rocm_setup_version(VERSION 0.5)
+rocm_setup_version(VERSION 0.5.1)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ROCMConfigVersion.cmake


### PR DESCRIPTION
Suggestion to resolve #47.

Use the `write_basic_package_version_file` function from `CMakePackageConfigHelpers` to create a version file detectable by CMake. Installing this file with `install` ensures that it will also be correctly packaged.