### PR TITLE
Fix invalid "Suggests:" field on old rpmbuild

### DIFF
--- a/cmake-format.yaml
+++ b/cmake-format.yaml
@@ -375,7 +375,7 @@ lint:
   # Require no more than this many newlines between statements
   max_statement_spacing: 2
   max_returns: 6
-  max_branches: 20
+  max_branches: 25
   max_arguments: 5
   max_localvars: 15
   max_statements: 120

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -101,8 +101,19 @@ macro(rocm_create_package)
             "${CPACK_PACKAGE_NAME}-devel (>=${CPACK_PACKAGE_VERSION})")
         rocm_join_if_set(", " CPACK_RPM_DEVEL_PACKAGE_REQUIRES
             "${CPACK_PACKAGE_NAME} >= ${CPACK_PACKAGE_VERSION}")
-        rocm_join_if_set(", " CPACK_RPM_UNSPECIFIED_PACKAGE_SUGGESTS
-            "${CPACK_PACKAGE_NAME}-devel >= ${CPACK_PACKAGE_VERSION}")
+        execute_process(
+            COMMAND rpmbuild --version
+            RESULT_VARIABLE PROC_RESULT
+            OUTPUT_VARIABLE EVAL_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(PROC_RESULT EQUAL "0" AND NOT EVAL_RESULT STREQUAL "")
+            string(REGEX MATCH "[0-9]+\.[0-9]+\.[0-9]+$" RPMBUILD_VERSION "${EVAL_RESULT}")
+            if (RPMBUILD_VERSION VERSION_GREATER_EQUAL "4.12.0")
+                rocm_join_if_set(", " CPACK_RPM_UNSPECIFIED_PACKAGE_SUGGESTS
+                    "${CPACK_PACKAGE_NAME}-devel >= ${CPACK_PACKAGE_VERSION}")
+            endif()
+        endif()
     endif()
 
     # '%{?dist}' breaks manual builds on debian systems due to empty Provides


### PR DESCRIPTION
Unfortunately this was missed in earlier testing, the "Suggests:" field used to smooth transitioning is not available on versions of rpmbuild prior to 4.12.0, which caused builds on Centos 7 to not generate the runtime package due to the invalid field. 

To pass the linter, the number of allowed branches was increased from 20 to 25.