### PR TITLE
Use ROCm platform version to automatically set rocm-core dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log for rocm-cmake
 
+## [0.6.2]
+### Changed
+- If the ROCm platform version that is being built for is less than version 4.5.0, `ROCM_DEP_ROCMCORE` is automatically disabled.
+  - The ROCm platform version is determined by:
+    - the user-set CMake variable `ROCM_PLATFORM_VERSION`; otherwise
+    - if the install prefix resolves to a path containing `rocm-<version>`, that version is used; otherwise
+    - if the real path to the version of `rocm-cmake` used contains `rocm-<version>`, that version is used.
+  - If the ROCm platform version is not set, then it is assumed to be greater than 4.5.0.
+
 ## [0.6.1]
 ### Added
 - Modules added to generate documentation:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/share/rocm/cmake)
 include(ROCMCreatePackage)
 include(ROCMSetupVersion)
 
-rocm_setup_version(VERSION 0.6.1)
+rocm_setup_version(VERSION 0.6.2)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ROCMConfigVersion.cmake

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -6,8 +6,8 @@ set(ROCM_DISABLE_LDCONFIG
     OFF
     CACHE BOOL "")
 
-get_filename_component(ROCM_CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" REALPATH)
-if(ROCM_CMAKE_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)*)" AND CMAKE_MATCH_0 VERSION_LESS 4.5.0)
+get_filename_component(ROCM_CMAKE_DIR "${ROCM_DIR}" REALPATH)
+if(ROCM_CMAKE_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)+)" AND CMAKE_MATCH_1 VERSION_LESS 4.5.0)
     set(ROCM_DEP_ROCMCORE FALSE CACHE BOOL "Add dependency on rocm-core package")
 else()
     set(ROCM_DEP_ROCMCORE TRUE CACHE BOOL "Add dependency on rocm-core package")

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -6,7 +6,12 @@ set(ROCM_DISABLE_LDCONFIG
     OFF
     CACHE BOOL "")
 
-set(ROCM_DEP_ROCMCORE TRUE CACHE BOOL "Add dependency on rocm-core package, default 'TRUE'")
+get_filename_component(ROCM_CMAKE_DIR ${CURRENT_SOURCE_DIR} REALPATH)
+if(ROCM_CMAKE_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)*)" AND CMAKE_MATCH_0 VERSION_LESS 4.5.0)
+    set(ROCM_DEP_ROCMCORE FALSE CACHE BOOL "Add dependency on rocm-core package")
+else()
+    set(ROCM_DEP_ROCMCORE TRUE CACHE BOOL "Add dependency on rocm-core package")
+endif()
 
 include(CMakeParseArguments)
 include(GNUInstallDirs)

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -6,9 +6,11 @@ set(ROCM_DISABLE_LDCONFIG
     OFF
     CACHE BOOL "")
 
-if(CMAKE_INSTALL_PREFIX MATCHES "rocm-([0-9]+(\.[0-9]+)+)")
+get_filename_component(REAL_ROCM "${CMAKE_INSTALL_PREFIX}" REALPATH)
+get_filename_component(REAL_ROCM_DIR "${ROCM_DIR}" REALPATH)
+if(REAL_ROCM MATCHES "rocm-([0-9]+(\.[0-9]+)+)")
     set(ROCM_PLATFORM_VERSION "${CMAKE_MATCH_1}" CACHE STRING "The version of the ROCm platform.")
-elseif(ROCM_CMAKE_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)+)")
+elseif(REAL_ROCM_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)+)")
     set(ROCM_PLATFORM_VERSION "${CMAKE_MATCH_1}" CACHE STRING "The version of the ROCm platform.")
 endif()
 if(DEFINED ROCM_PLATFORM_VERSION AND ROCM_PLATFORM_VERSION VERSION_LESS 4.5.0)

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -6,8 +6,12 @@ set(ROCM_DISABLE_LDCONFIG
     OFF
     CACHE BOOL "")
 
-get_filename_component(ROCM_CMAKE_DIR "${ROCM_DIR}" REALPATH)
-if(ROCM_CMAKE_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)+)" AND CMAKE_MATCH_1 VERSION_LESS 4.5.0)
+if(CMAKE_INSTALL_PREFIX MATCHES "rocm-([0-9]+(\.[0-9]+)+)")
+    set(ROCM_PLATFORM_VERSION "${CMAKE_MATCH_1}" CACHE STRING "The version of the ROCm platform.")
+elseif(ROCM_CMAKE_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)+)")
+    set(ROCM_PLATFORM_VERSION "${CMAKE_MATCH_1}" CACHE STRING "The version of the ROCm platform.")
+endif()
+if(DEFINED ROCM_PLATFORM_VERSION AND ROCM_PLATFORM_VERSION VERSION_LESS 4.5.0)
     set(ROCM_DEP_ROCMCORE FALSE CACHE BOOL "Add dependency on rocm-core package")
 else()
     set(ROCM_DEP_ROCMCORE TRUE CACHE BOOL "Add dependency on rocm-core package")

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -6,7 +6,7 @@ set(ROCM_DISABLE_LDCONFIG
     OFF
     CACHE BOOL "")
 
-get_filename_component(ROCM_CMAKE_DIR ${CURRENT_SOURCE_DIR} REALPATH)
+get_filename_component(ROCM_CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" REALPATH)
 if(ROCM_CMAKE_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)*)" AND CMAKE_MATCH_0 VERSION_LESS 4.5.0)
     set(ROCM_DEP_ROCMCORE FALSE CACHE BOOL "Add dependency on rocm-core package")
 else()

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -7,9 +7,7 @@ set(ROCM_DISABLE_LDCONFIG
     CACHE BOOL "")
 
 get_filename_component(REAL_ROCM "${CMAKE_INSTALL_PREFIX}" REALPATH)
-message("install dir ${REAL_ROCM}")
 get_filename_component(REAL_ROCM_DIR "${ROCM_DIR}" REALPATH)
-message("rocm dir ${REAL_ROCM_DIR}")
 if(REAL_ROCM MATCHES "rocm-([0-9]+(\.[0-9]+)+)")
     set(ROCM_PLATFORM_VERSION "${CMAKE_MATCH_1}" CACHE STRING "The version of the ROCm platform.")
 elseif(REAL_ROCM_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)+)")

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -7,9 +7,9 @@ set(ROCM_DISABLE_LDCONFIG
     CACHE BOOL "")
 
 get_filename_component(REAL_ROCM "${CMAKE_INSTALL_PREFIX}" REALPATH)
-message(REAL_ROCM)
+message("install dir ${REAL_ROCM}")
 get_filename_component(REAL_ROCM_DIR "${ROCM_DIR}" REALPATH)
-message(REAL_ROCM_DIR)
+message("rocm dir ${REAL_ROCM_DIR}")
 if(REAL_ROCM MATCHES "rocm-([0-9]+(\.[0-9]+)+)")
     set(ROCM_PLATFORM_VERSION "${CMAKE_MATCH_1}" CACHE STRING "The version of the ROCm platform.")
 elseif(REAL_ROCM_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)+)")

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -7,7 +7,9 @@ set(ROCM_DISABLE_LDCONFIG
     CACHE BOOL "")
 
 get_filename_component(REAL_ROCM "${CMAKE_INSTALL_PREFIX}" REALPATH)
+message(REAL_ROCM)
 get_filename_component(REAL_ROCM_DIR "${ROCM_DIR}" REALPATH)
+message(REAL_ROCM_DIR)
 if(REAL_ROCM MATCHES "rocm-([0-9]+(\.[0-9]+)+)")
     set(ROCM_PLATFORM_VERSION "${CMAKE_MATCH_1}" CACHE STRING "The version of the ROCm platform.")
 elseif(REAL_ROCM_DIR MATCHES "rocm-([0-9]+(\.[0-9]+)+)")


### PR DESCRIPTION
As the `rocm-core` package did not exist prior to ROCm version 4.5.0, packages built for prior versions of ROCm should not have this dependency. This code attempts to automatically determine the ROCm platform version, and if it is less than 4.5.0 then the package will not automatically depend on `rocm-core`.