### PR TITLE
Automatically install license

### DIFF
--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -318,7 +318,7 @@ macro(rocm_set_comp_cpackvar HEADER_ONLY components)
     # Setting component specific variables
     set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
     if(NOT CPACK_RESOURCE_FILE_LICENSE)
-        file(GLOB _license_files LIST_DIRECTORIES FALSE "${CMAKE_SOURCE_DIR}/LICENSE.*")
+        file(GLOB _license_files LIST_DIRECTORIES FALSE "${CMAKE_SOURCE_DIR}/LICENSE*")
         list(LENGTH _license_files _num_licenses)
         if(_num_licenses GREATER 1)
             message(AUTHOR_WARNING "rocm-cmake warning: Multiple license files found, please specify one using CPACK_RESOURCE_FILE_LICENSE.")

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -329,8 +329,12 @@ macro(rocm_setup_license HEADER_ONLY)
                 "rocm-cmake warning: Multiple license files found, "
                 "please specify one using CPACK_RESOURCE_FILE_LICENSE."
             )
-        elseif(_num_licenses GREATER 0)
-            message(STATUS "rocm-cmake: Set license file to ${CPACK_RESOURCE_FILE_LICENSE}.")
+        elseif(_num_licenses EQUAL 0)
+            message(AUTHOR_WARNING
+                "rocm-cmake warning: Could not find a license file, "
+                "please specify one using CPACK_RESOURCE_FILE_LICENSE."
+            )
+        else()
             list(GET _detected_license_files 0 CPACK_RESOURCE_FILE_LICENSE)
         endif()
     endif()

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -321,7 +321,10 @@ macro(rocm_set_comp_cpackvar HEADER_ONLY components)
         file(GLOB _license_files LIST_DIRECTORIES FALSE "${CMAKE_SOURCE_DIR}/LICENSE*")
         list(LENGTH _license_files _num_licenses)
         if(_num_licenses GREATER 1)
-            message(AUTHOR_WARNING "rocm-cmake warning: Multiple license files found, please specify one using CPACK_RESOURCE_FILE_LICENSE.")
+            message(AUTHOR_WARNING
+                "rocm-cmake warning: Multiple license files found, "
+                "please specify one using CPACK_RESOURCE_FILE_LICENSE."
+            )
         endif()
         if(_num_licenses GREATER 0)
             list(GET _license_files 0 _license_file)

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -329,12 +329,8 @@ macro(rocm_setup_license HEADER_ONLY)
                 "rocm-cmake warning: Multiple license files found, "
                 "please specify one using CPACK_RESOURCE_FILE_LICENSE."
             )
-        elseif(_num_licenses EQUAL 0)
-            message(AUTHOR_WARNING
-                "rocm-cmake warning: Could not find a license file, "
-                "please specify one using CPACK_RESOURCE_FILE_LICENSE."
-            )
-        else()
+        elseif(_num_licenses GREATER 0)
+            message(STATUS "rocm-cmake: Set license file to ${CPACK_RESOURCE_FILE_LICENSE}.")
             list(GET _detected_license_files 0 CPACK_RESOURCE_FILE_LICENSE)
         endif()
     endif()

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -317,6 +317,34 @@ endmacro()
 macro(rocm_set_comp_cpackvar HEADER_ONLY components)
     # Setting component specific variables
     set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+    if(NOT CPACK_RESOURCE_FILE_LICENSE)
+        file(GLOB _license_files LIST_DIRECTORIES FALSE "${CMAKE_SOURCE_DIR}/LICENSE.*")
+        list(LENGTH _license_files _num_licenses)
+        if(_num_licenses GREATER 1)
+            message(AUTHOR_WARNING "rocm-cmake warning: Multiple license files found, please specify one using CPACK_RESOURCE_FILE_LICENSE.")
+        endif()
+        if(_num_licenses GREATER 0)
+            list(GET _license_files 0 _license_file)
+            set(CPACK_RESOURCE_FILE_LICENSE "${_license_file}")
+        endif()
+    endif()
+
+    if(CPACK_RESOURCE_FILE_LICENSE)
+        if(NOT ${HEADER_ONLY})
+            install(
+                FILES ${CPACK_RESOURCE_FILE_LICENSE}
+                DESTINATION share/doc/${_rocm_cpack_package_name}
+                COMPONENT runtime
+            )
+        else()
+            install(
+                FILES ${CPACK_RESOURCE_FILE_LICENSE}
+                DESTINATION share/doc/${_rocm_cpack_package_name}
+                COMPONENT devel
+            )
+        endif()
+    endif()
+
     if(NOT ${HEADER_ONLY})
         set(CPACK_RPM_MAIN_COMPONENT "runtime")
         set(CPACK_RPM_RUNTIME_PACKAGE_NAME "${CPACK_PACKAGE_NAME}")

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -335,6 +335,7 @@ macro(rocm_setup_license HEADER_ONLY)
                 "please specify one using CPACK_RESOURCE_FILE_LICENSE."
             )
         else()
+            message(STATUS "rocm-cmake: Set license file to ${CPACK_RESOURCE_FILE_LICENSE}.")
             list(GET _detected_license_files 0 CPACK_RESOURCE_FILE_LICENSE)
         endif()
     endif()

--- a/test/libheaderonly/LICENSE
+++ b/test/libheaderonly/LICENSE
@@ -1,0 +1,3 @@
+This is a placeholder license file for the purposes of testing, and is not the license for this repository or the files
+contained in this directory. The license for rocm-cmake (including all files in this directory) can be located at 
+"https://github.com/RadeonOpenCompute/rocm-cmake/blob/master/LICENSE".

--- a/test/libsimple/LICENSE
+++ b/test/libsimple/LICENSE
@@ -1,0 +1,3 @@
+This is a placeholder license file for the purposes of testing, and is not the license for this repository or the files
+contained in this directory. The license for rocm-cmake (including all files in this directory) can be located at 
+"https://github.com/RadeonOpenCompute/rocm-cmake/blob/master/LICENSE".

--- a/test/libsimple2/LICENSE
+++ b/test/libsimple2/LICENSE
@@ -1,0 +1,3 @@
+This is a placeholder license file for the purposes of testing, and is not the license for this repository or the files
+contained in this directory. The license for rocm-cmake (including all files in this directory) can be located at 
+"https://github.com/RadeonOpenCompute/rocm-cmake/blob/master/LICENSE".

--- a/test/version/LICENSE
+++ b/test/version/LICENSE
@@ -1,0 +1,3 @@
+This is a placeholder license file for the purposes of testing, and is not the license for this repository or the files
+contained in this directory. The license for rocm-cmake (including all files in this directory) can be located at 
+"https://github.com/RadeonOpenCompute/rocm-cmake/blob/master/LICENSE".


### PR DESCRIPTION
If a license file was specified before calling rocm-create-package, install it to the correct location. If one wasn't specified, scan for a LICENSE(.*) file, then if one isn't found add it as the license file and install to the correct location.