### PR TITLE
Set CPACK_RPM_PACKAGE_LICENSE

### DIFF
--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -354,6 +354,11 @@ macro(rocm_setup_license HEADER_ONLY)
                 COMPONENT devel
             )
         endif()
+        file(READ ${CPACK_RESOURCE_FILE_LICENSE} LICENSEFILE)
+        string(FIND "${LICENSEFILE}" "MIT" MITCHECK)
+        if(NOT CPACK_RPM_PACKAGE_LICENSE AND ${MITCHECK} NOT EQUAL -1)
+                set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+        endif()
     endif()
 endmacro()
 


### PR DESCRIPTION
Please let me know if this is the wrong place to set it, or if MIT is incorrect.

It's only set on the top level, not per component. If there are multiple licenses (such as different subpackages/components have different licenses), it should be separated by "AND" (mix of licenses) or "OR" (either license may be used) such as "MIT AND NCSA" or "MIT OR ASL 2.0". Some examples of licenses are here:
https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#Software_License_List

RH and SUSE generally copy Fedora's "short name" as it's intended to be very machine-readable.