### PR TITLE
Create better default CPACK_GENERATOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log for rocm-cmake
 
+## [0.7.2]
+- `rocm_create_package` now will attempt to set a default `CPACK_GENERATOR` based on the `PKGTYPE` environment variable if one is not already set.
+
 ## [0.7.1]
 ### Added
 - `CLANG_TIDY_USE_COLOR` variable added to control the color output from `clang-tidy`, by default this is `On`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log for rocm-cmake
 
 ## [0.7.2]
-- `rocm_create_package` now will attempt to set a default `CPACK_GENERATOR` based on the `PKGTYPE` environment variable if one is not already set.
+- `rocm_create_package` now will attempt to set a default `CPACK_GENERATOR` based on the `ROCM_PKGTYPE` environment variable if one is not already set.
 
 ## [0.7.1]
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/share/rocm/cmake)
 include(ROCMCreatePackage)
 include(ROCMSetupVersion)
 
-rocm_setup_version(VERSION 0.7.1)
+rocm_setup_version(VERSION 0.7.2)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ROCMConfigVersion.cmake

--- a/doc/src/ROCMCreatePackage.rst
+++ b/doc/src/ROCMCreatePackage.rst
@@ -22,7 +22,7 @@ Commands
 Sets up CPack packaging, including installing the license file to the correct location and component.
 If the license file is not specified, also attempts to locate a LICENSE, LICENSE.md, or LICENSE.txt file in `CMAKE_SOURCE_DIR`.
 
-If the CPACK_GENERATOR has not been specified then if PKGTYPE is set
+If the CPACK_GENERATOR has not been specified then if ROCM_PKGTYPE is set
 then use that to set it, otherwise probe the system to see what
 programs are available.
 

--- a/doc/src/ROCMCreatePackage.rst
+++ b/doc/src/ROCMCreatePackage.rst
@@ -22,6 +22,10 @@ Commands
 Sets up CPack packaging, including installing the license file to the correct location and component.
 If the license file is not specified, also attempts to locate a LICENSE, LICENSE.md, or LICENSE.txt file in `CMAKE_SOURCE_DIR`.
 
+If the CPACK_GENERATOR has not been specified then if PKGTYPE is set
+then use that to set it, otherwise probe the system to see what
+programs are available.
+
 .. cmake:command:: rocm_package_add_rpm_dependencies
 
 .. code-block:: cmake

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -172,6 +172,53 @@ function(rocm_parse_python_syspath DIR_PATH PKG_NAME)
     ")
 endfunction()
 
+macro(rocm_set_cpack_gen)
+    # If CPACK_GENERATOR value has been given, then just use it
+    if(NOT CPACK_GENERATOR)
+	# If there is a PKGTYPE, use that as the desired type
+	if(DEFINED ENV{PKGTYPE})
+	    set(CPACK_GENERATOR "" ) # Create the variable if needed
+	    string(TOUPPER $ENV{PKGTYPE} CPACK_GENERATOR) # PKGTYPE is typically lower case
+	else()
+	    # Otherwise see what we can find
+	    message(INFO "rcom_set_cpack_gen didn't find PKGTYPE in environment")
+	    set(CPACK_GENERATOR "TGZ;ZIP")
+	    if(EXISTS ${MAKE_NSIS_EXE})
+		list(APPEND CPACK_GENERATOR "NSIS")
+	    endif()
+
+	    if(EXISTS ${RPMBUILD_EXE})
+		list(APPEND CPACK_GENERATOR "RPM")
+	    endif()
+
+	    if(EXISTS ${DPKG_EXE})
+		list(APPEND CPACK_GENERATOR "DEB")
+	    endif()
+	endif()
+    endif()
+    # Set up some additional variables depending on which generator we are going to use
+    if (CPACK_GENERATOR MATCHES ".*RPM.*")
+	if(PARSE_COMPONENTS)
+	    set(CPACK_RPM_COMPONENT_INSTALL ON)
+	endif()
+    endif()
+    if (CPACK_GENERATOR MATCHES ".*DEB.*")
+	if(EXISTS ${DPKG_EXE})
+	    if(PARSE_COMPONENTS)
+		set(CPACK_DEB_COMPONENT_INSTALL ON)
+		execute_process(
+		    COMMAND dpkg --print-architecture
+		    RESULT_VARIABLE PROC_RESULT
+		    OUTPUT_VARIABLE COMMAND_OUTPUT
+		    OUTPUT_STRIP_TRAILING_WHITESPACE)
+		if(PROC_RESULT EQUAL "0" AND NOT COMMAND_OUTPUT STREQUAL "")
+		    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${COMMAND_OUTPUT}")
+		endif()
+	    endif()
+	endif()
+    endif()
+endmacro()
+
 macro(rocm_create_package)
     set(options LDCONFIG PTH HEADER_ONLY)
     set(oneValueArgs NAME DESCRIPTION SECTION MAINTAINER LDCONFIG_DIR PREFIX)
@@ -187,6 +234,7 @@ macro(rocm_create_package)
     set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
     set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
     set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+    rocm_set_cpack_gen()	# Set CPACK_GENERATOR if not already set, based on PKGTYPE
     if(NOT CMAKE_HOST_WIN32)
         set(CPACK_SET_DESTDIR
             ON
@@ -252,44 +300,19 @@ macro(rocm_create_package)
         list(APPEND PARSE_COMPONENTS ${ROCM_PACKAGE_COMPONENTS})
     endif()
 
-    # '%{?dist}' breaks manual builds on debian systems due to empty Provides
-    execute_process(
-        COMMAND rpm --eval %{?dist}
-        RESULT_VARIABLE PROC_RESULT
-        OUTPUT_VARIABLE EVAL_RESULT
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(PROC_RESULT EQUAL "0" AND NOT EVAL_RESULT STREQUAL "")
-        string(APPEND RPM_RELEASE "%{?dist}")
+    if(CPACK_GENERATOR MATCHES ".*RPM.*")
+	# '%{?dist}' breaks manual builds on debian systems due to empty Provides
+	execute_process(
+            COMMAND rpm --eval %{?dist}
+            RESULT_VARIABLE PROC_RESULT
+            OUTPUT_VARIABLE EVAL_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(PROC_RESULT EQUAL "0" AND NOT EVAL_RESULT STREQUAL "")
+            string(APPEND RPM_RELEASE "%{?dist}")
+	endif()
     endif()
     set(CPACK_DEBIAN_PACKAGE_RELEASE ${DEBIAN_VERSION})
     set(CPACK_RPM_PACKAGE_RELEASE ${RPM_RELEASE})
-
-    set(CPACK_GENERATOR "TGZ;ZIP")
-    if(EXISTS ${MAKE_NSIS_EXE})
-        list(APPEND CPACK_GENERATOR "NSIS")
-    endif()
-
-    if(EXISTS ${RPMBUILD_EXE})
-        list(APPEND CPACK_GENERATOR "RPM")
-        if(PARSE_COMPONENTS)
-            set(CPACK_RPM_COMPONENT_INSTALL ON)
-        endif()
-    endif()
-
-    if(EXISTS ${DPKG_EXE})
-        list(APPEND CPACK_GENERATOR "DEB")
-        if(PARSE_COMPONENTS)
-            set(CPACK_DEB_COMPONENT_INSTALL ON)
-            execute_process(
-                COMMAND dpkg --print-architecture
-                RESULT_VARIABLE PROC_RESULT
-                OUTPUT_VARIABLE COMMAND_OUTPUT
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-            if(PROC_RESULT EQUAL "0" AND NOT COMMAND_OUTPUT STREQUAL "")
-                set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${COMMAND_OUTPUT}")
-            endif()
-        endif()
-    endif()
 
     if(PARSE_DEPENDS)
         rocm_package_add_dependencies(DEPENDS ${PARSE_DEPENDS})

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -175,47 +175,47 @@ endfunction()
 macro(rocm_set_cpack_gen)
     # If CPACK_GENERATOR value has been given, then just use it
     if(NOT CPACK_GENERATOR)
-	# If there is a PKGTYPE, use that as the desired type
-	if(DEFINED ENV{PKGTYPE})
-	    set(CPACK_GENERATOR "" ) # Create the variable if needed
-	    string(TOUPPER $ENV{PKGTYPE} CPACK_GENERATOR) # PKGTYPE is typically lower case
-	else()
-	    # Otherwise see what we can find
-	    message(INFO "rcom_set_cpack_gen didn't find PKGTYPE in environment")
-	    set(CPACK_GENERATOR "TGZ;ZIP")
-	    if(EXISTS ${MAKE_NSIS_EXE})
-		list(APPEND CPACK_GENERATOR "NSIS")
-	    endif()
+        # If there is a PKGTYPE, use that as the desired type
+        if(DEFINED ENV{PKGTYPE})
+            set(CPACK_GENERATOR "" ) # Create the variable if needed
+            string(TOUPPER $ENV{PKGTYPE} CPACK_GENERATOR) # PKGTYPE is typically lower case
+        else()
+            # Otherwise see what we can find
+            message(INFO "rcom_set_cpack_gen didn't find PKGTYPE in environment")
+            set(CPACK_GENERATOR "TGZ;ZIP")
+            if(EXISTS ${MAKE_NSIS_EXE})
+                list(APPEND CPACK_GENERATOR "NSIS")
+            endif()
 
-	    if(EXISTS ${RPMBUILD_EXE})
-		list(APPEND CPACK_GENERATOR "RPM")
-	    endif()
+            if(EXISTS ${RPMBUILD_EXE})
+                list(APPEND CPACK_GENERATOR "RPM")
+            endif()
 
-	    if(EXISTS ${DPKG_EXE})
-		list(APPEND CPACK_GENERATOR "DEB")
-	    endif()
-	endif()
+            if(EXISTS ${DPKG_EXE})
+                list(APPEND CPACK_GENERATOR "DEB")
+            endif()
+        endif()
     endif()
     # Set up some additional variables depending on which generator we are going to use
     if (CPACK_GENERATOR MATCHES ".*RPM.*")
-	if(PARSE_COMPONENTS)
-	    set(CPACK_RPM_COMPONENT_INSTALL ON)
-	endif()
+        if(PARSE_COMPONENTS)
+            set(CPACK_RPM_COMPONENT_INSTALL ON)
+        endif()
     endif()
     if (CPACK_GENERATOR MATCHES ".*DEB.*")
-	if(EXISTS ${DPKG_EXE})
-	    if(PARSE_COMPONENTS)
-		set(CPACK_DEB_COMPONENT_INSTALL ON)
-		execute_process(
-		    COMMAND dpkg --print-architecture
-		    RESULT_VARIABLE PROC_RESULT
-		    OUTPUT_VARIABLE COMMAND_OUTPUT
-		    OUTPUT_STRIP_TRAILING_WHITESPACE)
-		if(PROC_RESULT EQUAL "0" AND NOT COMMAND_OUTPUT STREQUAL "")
-		    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${COMMAND_OUTPUT}")
-		endif()
-	    endif()
-	endif()
+        if(EXISTS ${DPKG_EXE})
+            if(PARSE_COMPONENTS)
+                set(CPACK_DEB_COMPONENT_INSTALL ON)
+                execute_process(
+                    COMMAND dpkg --print-architecture
+                    RESULT_VARIABLE PROC_RESULT
+                    OUTPUT_VARIABLE COMMAND_OUTPUT
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+                if(PROC_RESULT EQUAL "0" AND NOT COMMAND_OUTPUT STREQUAL "")
+                    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${COMMAND_OUTPUT}")
+                endif()
+            endif()
+        endif()
     endif()
 endmacro()
 
@@ -234,7 +234,7 @@ macro(rocm_create_package)
     set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
     set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
     set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-    rocm_set_cpack_gen()	# Set CPACK_GENERATOR if not already set, based on PKGTYPE
+    rocm_set_cpack_gen()      # Set CPACK_GENERATOR if not already set
     if(NOT CMAKE_HOST_WIN32)
         set(CPACK_SET_DESTDIR
             ON
@@ -301,15 +301,15 @@ macro(rocm_create_package)
     endif()
 
     if(CPACK_GENERATOR MATCHES ".*RPM.*")
-	# '%{?dist}' breaks manual builds on debian systems due to empty Provides
-	execute_process(
+        # '%{?dist}' breaks manual builds on debian systems due to empty Provides
+        execute_process(
             COMMAND rpm --eval %{?dist}
             RESULT_VARIABLE PROC_RESULT
             OUTPUT_VARIABLE EVAL_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE)
-	if(PROC_RESULT EQUAL "0" AND NOT EVAL_RESULT STREQUAL "")
+        if(PROC_RESULT EQUAL "0" AND NOT EVAL_RESULT STREQUAL "")
             string(APPEND RPM_RELEASE "%{?dist}")
-	endif()
+        endif()
     endif()
     set(CPACK_DEBIAN_PACKAGE_RELEASE ${DEBIAN_VERSION})
     set(CPACK_RPM_PACKAGE_RELEASE ${RPM_RELEASE})

--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -176,9 +176,9 @@ macro(rocm_set_cpack_gen)
     # If CPACK_GENERATOR value has been given, then just use it
     if(NOT CPACK_GENERATOR)
         # If there is a PKGTYPE, use that as the desired type
-        if(DEFINED ENV{PKGTYPE})
+        if(DEFINED ENV{ROCM_PKGTYPE})
             set(CPACK_GENERATOR "" ) # Create the variable if needed
-            string(TOUPPER $ENV{PKGTYPE} CPACK_GENERATOR) # PKGTYPE is typically lower case
+            string(TOUPPER $ENV{ROCM_PKGTYPE} CPACK_GENERATOR) # PKGTYPE is typically lower case
         else()
             # Otherwise see what we can find
             message(INFO "rcom_set_cpack_gen didn't find PKGTYPE in environment")


### PR DESCRIPTION
Currently if a package doesn't specify a CPACK_GENERATOR the generated
one is excessive. rocBLAS generates several tarballs which are about
1GB in size each which are not used. This consumes I/O time slowing
the builds as well as using disk. Systems using "deb" files need to
install programs to create "rpm" packages and vice versa. With
generation of debug information these requirements become even more
stringent, for example the standard macros for packaging rpm debug
info require eu-strip to be installed.

If the build environment specifies a PKGTYPE variable and no
CPACK_GENERATOR is specified then set CPACK_GENERATOR based on this
value.

Change-Id: I14dcf59f6681d985f8e9ca25e68b4a3537835800