### PR TITLE
Make rocm_check_target_ids more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [0.7.3]
 ### Added
 - Header wrapper functionality included. This is to support the change in header file locations in ROCm 5.2, while providing backwards compatibility via header file wrappers.
+### Fixed
+- Fixed spurious failures in `rocm_check_target_ids` for target ids with target features when `-Werror` is enabled.
+  The `HAVE_<target-id>` result variable has been renamed to `COMPILER_HAS_TARGET_ID_<sanitized-target-id>`.
 
 ## [0.7.2]
 - `rocm_create_package` now will attempt to set a default `CPACK_GENERATOR` based on the `ROCM_PKGTYPE` environment variable if one is not already set.

--- a/share/rocm/cmake/ROCMCheckTargetIds.cmake
+++ b/share/rocm/cmake/ROCMCheckTargetIds.cmake
@@ -30,12 +30,12 @@ function(rocm_check_target_ids VARIABLE)
 endfunction()
 
 function(_rocm_sanitize_target_id TARGET_ID VARIABLE)
-    # Cmake defines a preprocessor macro with this value, so it must be a valid C identifier
+    # CMake defines a preprocessor macro with this value, so it must be a valid C identifier
     # Handle + and - for xnack and sramecc so that e.g. xnack+ and xnack- doesn't get folded to
     # the same string by MAKE_C_IDENTIFIER
     string(REPLACE "_" "__"   TARGET_ID "${TARGET_ID}")
-    string(REPLACE "+" "_ON"  TARGET_ID "${TARGET_ID}")
-    string(REPLACE "-" "_OFF" TARGET_ID "${TARGET_ID}")
+    string(REPLACE "+" "_on"  TARGET_ID "${TARGET_ID}")
+    string(REPLACE "-" "_off" TARGET_ID "${TARGET_ID}")
     string(MAKE_C_IDENTIFIER "${TARGET_ID}" TARGET_ID)
     set(${VARIABLE} "${TARGET_ID}" PARENT_SCOPE)
 endfunction()

--- a/share/rocm/cmake/ROCMCheckTargetIds.cmake
+++ b/share/rocm/cmake/ROCMCheckTargetIds.cmake
@@ -20,7 +20,7 @@ function(rocm_check_target_ids VARIABLE)
 
     foreach(_target_id ${PARSE_TARGETS})
         _rocm_sanitize_target_id("${_target_id}" _result_var)
-        set(_result_var "HAVE_${_result_var}")
+        set(_result_var "COMPILER_HAS_TARGET_ID_${_result_var}")
         check_cxx_compiler_flag("-xhip --offload-arch=${_target_id}" "${_result_var}")
         if(${_result_var})
             list(APPEND _supported_target_ids "${_target_id}")

--- a/share/rocm/cmake/ROCMCheckTargetIds.cmake
+++ b/share/rocm/cmake/ROCMCheckTargetIds.cmake
@@ -1,5 +1,5 @@
 # ######################################################################################################################
-# Copyright (C) 2022 Advanced Micro Devices, Inc.
+# Copyright (C) 2021-2022 Advanced Micro Devices, Inc.
 # ######################################################################################################################
 
 include(CheckCXXCompilerFlag)
@@ -26,7 +26,7 @@ function(rocm_check_target_ids VARIABLE)
             list(APPEND _supported_target_ids "${_target_id}")
         endif()
     endforeach()
-    set("${VARIABLE}" "${_supported_target_ids}" PARENT_SCOPE)
+    set(${VARIABLE} "${_supported_target_ids}" PARENT_SCOPE)
 endfunction()
 
 function(_rocm_sanitize_target_id TARGET_ID VARIABLE)
@@ -37,5 +37,5 @@ function(_rocm_sanitize_target_id TARGET_ID VARIABLE)
     string(REPLACE "+" "_ON"  TARGET_ID "${TARGET_ID}")
     string(REPLACE "-" "_OFF" TARGET_ID "${TARGET_ID}")
     string(MAKE_C_IDENTIFIER "${TARGET_ID}" TARGET_ID)
-    set("${VARIABLE}" "${TARGET_ID}" PARENT_SCOPE)
+    set(${VARIABLE} "${TARGET_ID}" PARENT_SCOPE)
 endfunction()

--- a/share/rocm/cmake/ROCMCheckTargetIds.cmake
+++ b/share/rocm/cmake/ROCMCheckTargetIds.cmake
@@ -1,5 +1,5 @@
 # ######################################################################################################################
-# Copyright (C) 2021 Advanced Micro Devices, Inc.
+# Copyright (C) 2022 Advanced Micro Devices, Inc.
 # ######################################################################################################################
 
 include(CheckCXXCompilerFlag)
@@ -19,11 +19,23 @@ function(rocm_check_target_ids VARIABLE)
     endif()
 
     foreach(_target_id ${PARSE_TARGETS})
-        set(_result_var "HAVE_${_target_id}")
+        _rocm_sanitize_target_id("${_target_id}" _result_var)
+        set(_result_var "HAVE_${_result_var}")
         check_cxx_compiler_flag("-xhip --offload-arch=${_target_id}" "${_result_var}")
         if(${_result_var})
             list(APPEND _supported_target_ids "${_target_id}")
         endif()
     endforeach()
-    set(${VARIABLE} "${_supported_target_ids}" PARENT_SCOPE)
+    set("${VARIABLE}" "${_supported_target_ids}" PARENT_SCOPE)
+endfunction()
+
+function(_rocm_sanitize_target_id TARGET_ID VARIABLE)
+    # Cmake defines a preprocessor macro with this value, so it must be a valid C identifier
+    # Handle + and - for xnack and sramecc so that e.g. xnack+ and xnack- doesn't get folded to
+    # the same string by MAKE_C_IDENTIFIER
+    string(REPLACE "_" "__"   TARGET_ID "${TARGET_ID}")
+    string(REPLACE "+" "_ON"  TARGET_ID "${TARGET_ID}")
+    string(REPLACE "-" "_OFF" TARGET_ID "${TARGET_ID}")
+    string(MAKE_C_IDENTIFIER "${TARGET_ID}" TARGET_ID)
+    set("${VARIABLE}" "${TARGET_ID}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Add support for target features for rocm_check_target ids. Before this change targets with target features specified (like xnack or sramecc) would fail. 

EDIT: the autodetection only fails (at least on clang) when `-Werror` is included in `CMAKE_CXX_FLAGS` because by default clang only issues a diagnostic not an error.