### PR TITLE
Remove redundant check for parent directory

### DIFF
--- a/share/rocm/cmake/ROCMHeaderWrapper.cmake
+++ b/share/rocm/cmake/ROCMHeaderWrapper.cmake
@@ -24,16 +24,14 @@ function(rocm_wrap_header_dir DIRECTORY)
     endforeach()
     file (GLOB_RECURSE include_files RELATIVE "${DIRECTORY}" ${QUALIFIED_PATTERNS})
     foreach (include_file ${include_files})
-        if (NOT "${include_file}" MATCHES "^\.\./")
-            rocm_wrap_header_file(
-                ${include_file}
-                GUARDS ${PARSE_GUARDS}
-                HEADER_LOCATION ${PARSE_HEADER_LOCATION}
-                INCLUDE_LOCATION ${PARSE_INCLUDE_LOCATION}
-                WRAPPER_LOCATIONS ${PARSE_WRAPPER_LOCATIONS}
-                OUTPUT_LOCATIONS ${PARSE_OUTPUT_LOCATIONS}
-            )
-        endif()
+        rocm_wrap_header_file(
+            ${include_file}
+            GUARDS ${PARSE_GUARDS}
+            HEADER_LOCATION ${PARSE_HEADER_LOCATION}
+            INCLUDE_LOCATION ${PARSE_INCLUDE_LOCATION}
+            WRAPPER_LOCATIONS ${PARSE_WRAPPER_LOCATIONS}
+            OUTPUT_LOCATIONS ${PARSE_OUTPUT_LOCATIONS}
+        )
     endforeach()
 endfunction()
 

--- a/share/rocm/cmake/ROCMHeaderWrapper.cmake
+++ b/share/rocm/cmake/ROCMHeaderWrapper.cmake
@@ -24,7 +24,7 @@ function(rocm_wrap_header_dir DIRECTORY)
     endforeach()
     file (GLOB_RECURSE include_files RELATIVE "${DIRECTORY}" ${QUALIFIED_PATTERNS})
     foreach (include_file ${include_files})
-        if (NOT "${include_file}" MATCHES "^../")
+        if (NOT "${include_file}" MATCHES "^\.\./")
             rocm_wrap_header_file(
                 ${include_file}
                 GUARDS ${PARSE_GUARDS}


### PR DESCRIPTION
This check is unnecessary and incorrect, as it filters out all 2-letter directories when using this function.