### PR TITLE
Only link library specific files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         platform:
           - ubuntu-18.04
           - macos-10.14
-          - windows-2016
+          - windows-2022
         cmake-version:
           - 3.20.0
           - 3.10.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
         cmake-version:
           - 3.20.0
           - 3.10.2
+        exclude:
+          - platform: windows-2019
+            cmake-version: 3.10.2
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         platform:
           - ubuntu-18.04
           - macos-10.14
-          - windows-2022
+          - windows-2019
         cmake-version:
           - 3.20.0
           - 3.10.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         platform:
           - ubuntu-18.04
-          - macos-10.14
+          - macos-10.15
           - windows-2019
         cmake-version:
           - 3.20.0

--- a/share/rocm/cmake/ROCMInstallTargets.cmake
+++ b/share/rocm/cmake/ROCMInstallTargets.cmake
@@ -346,5 +346,4 @@ function(rocm_export_targets)
             ")
         rocm_install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/cmake_symlink.cmake")
     endif()
-    
 endfunction()

--- a/share/rocm/cmake/ROCMInstallTargets.cmake
+++ b/share/rocm/cmake/ROCMInstallTargets.cmake
@@ -159,7 +159,8 @@ function(rocm_install_targets)
                         NAMELINK_ONLY
             )
         endif()
-        if(ROCM_SYMLINK_LIBS AND NOT WIN32 AND T_TYPE MATCHES ".*_LIBRARY")
+        if(ROCM_SYMLINK_LIBS AND NOT WIN32 AND T_TYPE MATCHES ".*_LIBRARY"
+            AND NOT T_TYPE STREQUAL "INTERFACE_LIBRARY")
             string(TOLOWER "${PROJECT_NAME}" LINK_SUBDIR)
             file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_symlink.cmake
                 CONTENT "

--- a/share/rocm/cmake/ROCMInstallTargets.cmake
+++ b/share/rocm/cmake/ROCMInstallTargets.cmake
@@ -160,26 +160,26 @@ function(rocm_install_targets)
             )
         endif()
         if(T_TYPE MATCHES ".*_LIBRARY" AND ROCM_SYMLINK_LIBS AND NOT CMAKE_HOST_WIN32)
-            cmake_policy(SET CMP0087 NEW)
 
             string(TOLOWER "${PROJECT_NAME}" LINK_SUBDIR)
 
-            set(INSTALL_CMD "
+            file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_symlink.cmake
+                    CONTENT "
                 set(SRC_DIR \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX})
                 set(LINK_DIR \${SRC_DIR}/${LINK_SUBDIR})
                 if(NOT EXISTS \${LINK_DIR}/${ROCM_INSTALL_LIBDIR}/cmake)
                     file(MAKE_DIRECTORY \${LINK_DIR}/${ROCM_INSTALL_LIBDIR}/cmake)
                     execute_process(COMMAND
-                        ln -srf ${SRC_DIR}/${ROCM_INSTALL_LIBDIR}/cmake/${LINK_SUBDIR}
+                        ln -srf \${SRC_DIR}/${ROCM_INSTALL_LIBDIR}/cmake/${LINK_SUBDIR}
                         \${LINK_DIR}/${ROCM_INSTALL_LIBDIR}/cmake/${LINK_SUBDIR}
                     )
                 endif()
                 execute_process(COMMAND
-                    ln -srf ${SRC_DIR}/${ROCM_INSTALL_LIBDIR}/$<TARGET_LINKER_FILE_NAME:${TARGET}>
+                    ln -srf \${SRC_DIR}/${ROCM_INSTALL_LIBDIR}/\$<TARGET_LINKER_FILE_NAME:${TARGET}>
                     \${LINK_DIR}/${ROCM_INSTALL_LIBDIR}/$<TARGET_LINKER_FILE_NAME:${TARGET}>
                 )
             ")
-            rocm_install(CODE "${INSTALL_CMD}")
+            rocm_install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_symlink.cmake")
         endif()
     endforeach()
 endfunction()

--- a/test/test.cmake
+++ b/test/test.cmake
@@ -109,7 +109,7 @@ function(install_dir DIR)
     configure_dir(
         ${DIR}
         TARGETS all ${PARSE_TARGETS} install
-        CMAKE_ARGS ${PARSE_CMAKE_ARGS})
+        CMAKE_ARGS ${PARSE_CMAKE_ARGS} -DROCM_SYMLINK_LIBS=OFF)
 endfunction()
 
 function(write_version_cmake DIR VERSION CONTENT)


### PR DESCRIPTION
This is not compatible with CMake 3.10 (due to the use of generator expressions in `install(CODE)`, requiring the setting of `CMP0087`). Can anyone think of a better method to do the same thing?