### PR TITLE
Remove INFOrocm_set_cpack_gen message

### DIFF
--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -181,7 +181,6 @@ macro(rocm_set_cpack_gen)
             string(TOUPPER $ENV{ROCM_PKGTYPE} CPACK_GENERATOR) # PKGTYPE is typically lower case
         else()
             # Otherwise see what we can find
-            message(INFO "rocm_set_cpack_gen didn't find ROCM_PKGTYPE in environment")
             set(CPACK_GENERATOR "TGZ;ZIP")
             if(EXISTS ${MAKE_NSIS_EXE})
                 list(APPEND CPACK_GENERATOR "NSIS")


### PR DESCRIPTION
INFO is not a valid mode for CMake [`message`](https://cmake.org/cmake/help/latest/command/message.html), so it is interpreted as a plain string, printing "INFOrocm_set_cpack_gen didn't..." The message is not particularly useful anyway, so it might as well be removed.