### PR TITLE
Changing #warning to #pragma message.

### DIFF
--- a/share/rocm/cmake/header_template.h.in
+++ b/share/rocm/cmake/header_template.h.in
@@ -11,7 +11,7 @@
 #if defined(_MSC_VER)
 #pragma message(": warning:This file is deprecated. Use the header file from @header_location@ by using #include <@correct_include@>")
 #elif defined(__GNUC__)
-#warning "This file is deprecated. Use the header file from @header_location@ by using #include <@correct_include@>"
+#pragma message(": warning : This file is deprecated. Use the header file from @header_location@ by using #include <@correct_include@>")
 #endif
 #include "@file_rel_path@"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,10 @@ foreach(TEST ${PASS_TESTS})
 endforeach()
 
 file(GLOB FAIL_TESTS fail/*.cmake)
+# Disable wrapper fail test, as the warning is changed to message
+# This is temporary and will be enabled back later when the behavior is reverted
+list(FILTER FAIL_TESTS EXCLUDE REGEX ".*wrapper\.cmake$")
+
 foreach(TEST ${FAIL_TESTS})
     get_filename_component(NAME ${TEST} NAME_WE)
     create_test(fail-${NAME} ${TEST})


### PR DESCRIPTION
Some of the upstream apps like Onnx-RT is failing compilation due to #warning.
Changing #warning to #pragma and it will be reverted back to #warning after 1-2 ROCm release