### PR TITLE
Add ROCM_NO_WRAPPER_HEADER_WARNING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.7.3]
 ### Added
 - Header wrapper functionality included. This is to support the change in header file locations in ROCm 5.2, while providing backwards compatibility via header file wrappers.
+  The associated deprecation warning can be disabled by defining `ROCM_NO_WRAPPER_HEADER_WARNING` before including the wrapper header.
 ### Fixed
 - Fixed spurious failures in `rocm_check_target_ids` for target ids with target features when `-Werror` is enabled.
   The `HAVE_<target-id>` result variable has been renamed to `COMPILER_HAS_TARGET_ID_<sanitized-target-id>`.

--- a/doc/src/ROCMHeaderWrapper.rst
+++ b/doc/src/ROCMHeaderWrapper.rst
@@ -17,7 +17,9 @@ Commands
         [OUTPUT_LOCATIONS <output-location>...]
     )
 
-Create a C/C++ wrapper file for each specified header file.
+Create a C/C++ wrapper file for each specified header file. The wrapper is simply a C/C++ header
+that emits a deprecation warning before including its corresponding header. The warning can be
+turned off by defining ``ROCM_NO_WRAPPER_HEADER_WARNING``.
 
 Any relative header or wrapper locations are relative to ``${CPACK_PACKAGING_INSTALL_PREFIX}`` if it is set,
 or to ``${CMAKE_INSTALL_PREFIX}`` otherwise (i.e. the install directory).
@@ -72,7 +74,7 @@ Its include guard will be ``ROCM_EXAMPLE_INC_FOO_BAR_H``, and it will include th
 
 .. code-block:: cmake
 
-    rocm_wrap_header_file(
+    rocm_wrap_header_dir(
         <include-directory>
         [HEADER_LOCATION <header-location>]
         [GUARDS <guard>...]

--- a/share/rocm/cmake/header_template.h.in
+++ b/share/rocm/cmake/header_template.h.in
@@ -19,6 +19,6 @@
 #define ROCM_@ITEM_GUARD@_GAVE_WARNING
 #include "@file_rel_path@"
 #undef ROCM_@ITEM_GUARD@_GAVE_WARNING
-#endif /* defined(ROCM_@ITEM_GUARD@_NO_WARNING) || defined(ROCM_@ITEM_GUARD@_GAVE_WARNING) */
+#endif /* defined(ROCM_NO_WRAPPER_HEADER_WARNING) || defined(ROCM_@ITEM_GUARD@_GAVE_WARNING) */
 
 #endif /* @include_guard@ */

--- a/share/rocm/cmake/header_template.h.in
+++ b/share/rocm/cmake/header_template.h.in
@@ -5,21 +5,20 @@
 #ifndef @include_guard@
 #define @include_guard@
 
-#ifndef ROCM_@ITEM_GUARD@_GAVE_WARNING
-#define ROCM_@ITEM_GUARD@_GAVE_WARNING
-
+#if defined(ROCM_NO_WRAPPER_HEADER_WARNING) || defined(ROCM_@ITEM_GUARD@_GAVE_WARNING)
+/* include file */
+#include "@file_rel_path@"
+#else
+/* give warning */
 #if defined(_MSC_VER)
 #pragma message(": warning:This file is deprecated. Use the header file from @header_location@ by using #include <@correct_include@>")
 #elif defined(__GNUC__)
 #warning "This file is deprecated. Use the header file from @header_location@ by using #include <@correct_include@>"
 #endif
+/* include file */
+#define ROCM_@ITEM_GUARD@_GAVE_WARNING
 #include "@file_rel_path@"
-
 #undef ROCM_@ITEM_GUARD@_GAVE_WARNING
-#else
+#endif /* defined(ROCM_@ITEM_GUARD@_NO_WARNING) || defined(ROCM_@ITEM_GUARD@_GAVE_WARNING) */
 
-#include "@file_rel_path@"
-
-#endif // ROCM_@ITEM_GUARD@_GAVE_WARNING
-
-#endif // @include_guard@
+#endif /* @include_guard@ */

--- a/test/pass/wrapper-nowarn.cmake
+++ b/test/pass/wrapper-nowarn.cmake
@@ -1,0 +1,34 @@
+# ######################################################################################################################
+# Copyright (C) 2022 Advanced Micro Devices, Inc.
+# ######################################################################################################################
+
+install_dir(${TEST_DIR}/libwrapper
+    CMAKE_ARGS -DBUILD_SHARED_LIBS=On -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=On -DERR_ON_WARN=ON
+        -DCMAKE_CXX_FLAGS='-DROCM_NO_WRAPPER_HEADER_WARNING')
+test_check_package(
+    NAME test-wrapper
+    HEADER wrapper.h
+    TARGET wrapper)
+test_check_package(
+    NAME test-wrapper
+    HEADER wrapper/wrapper.h
+    TARGET wrapper
+)
+test_check_package(
+    NAME test-wrapper
+    HEADER other.h
+    TARGET wrapper)
+test_check_package(
+    NAME test-wrapper
+    HEADER other/other.h
+    TARGET wrapper
+)
+test_check_package(
+    NAME test-wrapper
+    HEADER other/th/two-letter-dir.h
+    TARGET wrapper)
+test_check_package(
+    NAME test-wrapper
+    HEADER th/two-letter-dir.h
+    TARGET wrapper
+)


### PR DESCRIPTION
This is checks if `ROCM_NO_WRAPPER_HEADER_WARNING` is defined and applies the same logic as was already being used for `ROCM_@ITEM_GUARD@_GAVE_WARNING`. It basically exists so users can use a more meaningful define in their build code than `ROCM_SYMLINK_GAVE_WARNING` and `ROCM_WRAPPER_GAVE_WARNING`. The template header diff might look a bit messy because I inverted the if/else.

The `pass/wrapper-nowarn.cmake` tests were copied from `fail/wrapper.cmake` but had `-DROCM_NO_WRAPPER_HEADER_WARNING` added to their compiler flags. There's also minor fixes to the docs and I changed the comment style to be C89 compatible... just in case.