### PR TITLE
Fix use of LIBDIR

### DIFF
--- a/share/rocm/cmake/ROCMInstallTargets.cmake
+++ b/share/rocm/cmake/ROCMInstallTargets.cmake
@@ -4,11 +4,14 @@
 
 cmake_policy(SET CMP0057 NEW)
 
+# Default libdir to "lib", this skips GNUInstallDirs from trying to take a guess if it's unset:
+set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")
+
 include(CMakeParseArguments)
 include(GNUInstallDirs)
 include(ROCMPackageConfigHelpers)
 
-set(ROCM_INSTALL_LIBDIR lib)
+set(ROCM_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
 if(WIN32)
     set(ROCM_USE_DEV_COMPONENT OFF CACHE BOOL "Generate a devel package?")
 else()


### PR DESCRIPTION
This issue was found with the help of @cgmb , it looks like a lot of people have been adding this to their cmake files:

```
# Force library install path to lib (CentOS 7 defaults to lib64)
set(CMAKE_INSTALL_LIBDIR "lib" CACHE INTERNAL "Installation directory for libraries" FORCE)
```

This is not a good idea, as non-rocm builders, such as distros, will want to override the value of CMAKE_INSTALL_LIBDIR. While the use of GNUInstallDirs is a good idea in ROCMInstallTargets, as it will set sane defaults to the CMAKE_INSTALL_* variables, it also has an unintended side effect of trying to guess what to use for libdir.

We saw this issue in other components, so @frepaul had a good suggestion to set libdir prior to including GNUInstallDirs. This allows for us to have "lib" as a predicable default, but still have the advantage of overriding directories, as intended by GNUInstallDirs.

I've already implemented this logic in ROCr and OpenCL, but they haven't been merged into github yet.