### PR TITLE
Ensure CMAKE_INSTALL_LIBDIR is set consistently

### DIFF
--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -21,6 +21,10 @@ else()
     set(ROCM_DEP_ROCMCORE TRUE CACHE BOOL "Add dependency on rocm-core package")
 endif()
 
+# todo: consolidate with duplicate in ROCMInstallTargets.cmake
+# Default libdir to "lib", this skips GNUInstallDirs from trying to take a guess if it's unset:
+set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")
+
 include(CMakeParseArguments)
 include(GNUInstallDirs)
 include(ROCMSetupVersion)

--- a/share/rocm/cmake/ROCMInstallTargets.cmake
+++ b/share/rocm/cmake/ROCMInstallTargets.cmake
@@ -4,6 +4,7 @@
 
 cmake_policy(SET CMP0057 NEW)
 
+# todo: consolidate with duplicate in ROCMCreatePackage.cmake
 # Default libdir to "lib", this skips GNUInstallDirs from trying to take a guess if it's unset:
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")
 


### PR DESCRIPTION
There's another `include(GNUInstallDirs)` in `ROCMCreatePackage.cmake`, so we were getting different behaviour depending on the order of includes.