### PR TITLE
Silence RPM not found warning by adding QUIET

### DIFF
--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -308,7 +308,7 @@ macro(rocm_create_package)
         rocm_join_if_set(", " CPACK_DEBIAN_RUNTIME_PACKAGE_RECOMMENDS
             "${CPACK_PACKAGE_NAME}-dev (>=${CPACK_PACKAGE_VERSION})")
 
-        rocm_find_program_version(rpmbuild GREATER_EQUAL 4.12.0)
+        rocm_find_program_version(rpmbuild GREATER_EQUAL 4.12.0 QUIET)
         if(rpmbuild_VERSION_OK)
             rocm_join_if_set(", " CPACK_RPM_RUNTIME_PACKAGE_SUGGESTS
                 "${CPACK_PACKAGE_NAME}-devel >= ${CPACK_PACKAGE_VERSION}"


### PR DESCRIPTION
When not building RPM packages a warning about `rpm` still shows up when a development package is requested.

"CMake Warning at /opt/rocm/share/rocm/cmake/ROCMUtilities.cmake:50 (message): 
Could not determine the version of program rpmbuild."

As this is only an optional check used to add rpm specific dependency info to the package, it should be okay to silence this warning.