### PR TITLE
ROCmCreatePackage: Fix pth uninstall

### DIFF
--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -160,7 +160,7 @@ function(rocm_parse_python_syspath DIR_PATH PKG_NAME)
         file(
             APPEND ${PROJECT_BINARY_DIR}/debian/prerm
             "
-            rm ${PYTHON_SITE}/${PKG_NAME}.pth
+            rm -f ${PYTHON_SITE}/${PKG_NAME}.pth
         ")
     endforeach()
     #end function and invoke the function


### PR DESCRIPTION
Fix for python hooks. For libraries that don't install their python api by default this seems to break workflow for the uninstall/update procedure with these libraries.