### PR TITLE
Switch to test on `macos-11`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         platform:
           - ubuntu-18.04
-          - macos-10.15
+          - macos-11
           - windows-2019
         cmake-version:
           - 3.20.0


### PR DESCRIPTION
The GitHub runner `macos-10.15` is deprecated and will be removed as of August 30, 2022. Therefore, switching to use the `macos-11` runner.