### PR TITLE
Fix own cmake files - also create symlink from INCLUDE cmake

### DIFF
--- a/share/rocm/cmake/ROCMInstallTargets.cmake
+++ b/share/rocm/cmake/ROCMInstallTargets.cmake
@@ -263,6 +263,8 @@ function(rocm_export_targets)
 
     set(CONFIG_TEMPLATE "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME_LOWER}-config.cmake.in")
 
+    set(INCLUDED_FILES "")
+
     file(
         WRITE ${CONFIG_TEMPLATE}
         "
@@ -289,7 +291,7 @@ function(rocm_export_targets)
     foreach(INCLUDE ${PARSE_INCLUDE})
         rocm_install(FILES ${INCLUDE} DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR})
         get_filename_component(INCLUDE_BASE ${INCLUDE} NAME)
-        list(APPEND PARSE_INCLUDE_NAME ${INCLUDE_BASE})
+        list(APPEND INCLUDED_FILES ${INCLUDE_BASE})
         rocm_write_package_template_function(${CONFIG_TEMPLATE} include "\${CMAKE_CURRENT_LIST_DIR}/${INCLUDE_BASE}")
     endforeach()
 
@@ -337,6 +339,7 @@ function(rocm_export_targets)
             CONTENT "
             set(SRC_DIR \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CONFIG_PACKAGE_INSTALL_DIR})
             set(LINK_DIR \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LINK_SUBDIR}/${ROCM_INSTALL_LIBDIR}/cmake)
+            set(INCLUDED_FILES \"${INCLUDED_FILES}\")
             if(NOT EXISTS \${LINK_DIR})
                 file(MAKE_DIRECTORY \${LINK_DIR})
             endif()
@@ -345,8 +348,7 @@ function(rocm_export_targets)
                 RELATIVE \${SRC_DIR}
                 \${SRC_DIR}/${TARGET_FILE}*.cmake
             )
-            set(PARSE_INCLUDE_NAME \"${PARSE_INCLUDE_NAME}\")
-            foreach(filename ${CONFIG_NAME}.cmake ${CONFIG_NAME}-version.cmake \${TARGET_FILES} \${PARSE_INCLUDE_NAME})
+            foreach(filename ${CONFIG_NAME}.cmake ${CONFIG_NAME}-version.cmake \${TARGET_FILES} \${INCLUDED_FILES})
                 file(RELATIVE_PATH LINK_PATH \${LINK_DIR} \${SRC_DIR}/\${filename})
                 if(NOT EXISTS \${LINK_DIR}/\${filename})
                     execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink

--- a/share/rocm/cmake/ROCMInstallTargets.cmake
+++ b/share/rocm/cmake/ROCMInstallTargets.cmake
@@ -289,6 +289,7 @@ function(rocm_export_targets)
     foreach(INCLUDE ${PARSE_INCLUDE})
         rocm_install(FILES ${INCLUDE} DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR})
         get_filename_component(INCLUDE_BASE ${INCLUDE} NAME)
+        list(APPEND PARSE_INCLUDE_NAME ${INCLUDE_BASE})
         rocm_write_package_template_function(${CONFIG_TEMPLATE} include "\${CMAKE_CURRENT_LIST_DIR}/${INCLUDE_BASE}")
     endforeach()
 
@@ -344,7 +345,8 @@ function(rocm_export_targets)
                 RELATIVE \${SRC_DIR}
                 \${SRC_DIR}/${TARGET_FILE}*.cmake
             )
-            foreach(filename ${CONFIG_NAME}.cmake ${CONFIG_NAME}-version.cmake \${TARGET_FILES})
+            set(PARSE_INCLUDE_NAME \"${PARSE_INCLUDE_NAME}\")
+            foreach(filename ${CONFIG_NAME}.cmake ${CONFIG_NAME}-version.cmake \${TARGET_FILES} \${PARSE_INCLUDE_NAME})
                 file(RELATIVE_PATH LINK_PATH \${LINK_DIR} \${SRC_DIR}/\${filename})
                 if(NOT EXISTS \${LINK_DIR}/\${filename})
                     execute_process(COMMAND \${CMAKE_COMMAND} -E create_symlink


### PR DESCRIPTION
from 5.2.0, hip and rocm will also add cmake file into `<ROCM>/<PACKAGE>/lib/cmake` (not just `<ROCM>/lib/cmake/<PACAKGE>`)
hiprand and rocrand reports `include could not find load file: ...`
The workaround is link the missing file from `<ROCM>/lib/cmake/<PACAKGE>` to `<ROCM>/<PACKAGE>/lib/cmake`  or use `-D<pacakge_lower_case>_DIR=<ROCM>/<PACKAGE>/lib/cmake` in CMake

Issue:
When cmake find the file inside `<ROCM>/<PACKAGE>/lib/cmake`, it will create issue about cmakefile non-found.
https://github.com/RadeonOpenCompute/rocm-cmake/blob/03ec8374afec9d96afb9cc817fb9258feb84ed32/share/rocm/cmake/ROCMInstallTargets.cmake#L289-L293
only adds the INCLUDE cmake into CONFIG_PACKAGE_INSTALL_DIR, which is `lib/cmake/<PACKAGE>`
and looks for the file from current cmake folder. ( `<ROCM>/<PACKAGE>/lib/cmake`)
Thus, it can not find the file because symlink is not created.

also create the symlink for INCLUDE cmakefile.
another way is to change the path to look for the INCLUDE, but I think all cmake should be under the same folder from the rocm cmakefile structure
