### PR TITLE
Set project languages to NONE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required (VERSION 3.6)
 
 set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "")
 
-project(rocm-cmake)
+project(rocm-cmake LANGUAGES NONE)
 
 install(DIRECTORY share DESTINATION .)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ROCMConfigVersion.cmake DESTINATION share/rocm/cmake)

--- a/test/analyze/CMakeLists.txt
+++ b/test/analyze/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 
 cmake_minimum_required (VERSION 3.5)
-project(simple)
+project(simple LANGUAGES CXX)
 
 find_package(ROCM)
 

--- a/test/findpackagecheck/CMakeLists.txt
+++ b/test/findpackagecheck/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required (VERSION 3.5)
-project(findpackagecheck)
+project(findpackagecheck CXX)
 
 message(STATUS "PKG: ${PKG}")
 message(STATUS "PKG_TARGET: ${PKG_TARGET}")
@@ -17,4 +17,3 @@ configure_file(main.cpp.in main.cpp @ONLY)
 add_executable(main ${CMAKE_CURRENT_BINARY_DIR}/main.cpp)
 target_link_libraries(main ${PKG_TARGET})
 install(TARGETS main DESTINATION bin)
-

--- a/test/libbasic/CMakeLists.txt
+++ b/test/libbasic/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 
 cmake_minimum_required (VERSION 3.5)
-project(basic)
+project(basic CXX)
 
 find_package(ROCM)
 find_package(simple)
@@ -24,4 +24,3 @@ target_link_libraries(basic PRIVATE simple)
 
 rocm_install_targets(TARGETS basic INCLUDE include)
 rocm_export_targets(TARGETS basic STATIC_DEPENDS simple)
-

--- a/test/libheaderonly/CMakeLists.txt
+++ b/test/libheaderonly/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 
 cmake_minimum_required (VERSION 3.5)
-project(headeronly)
+project(headeronly LANGUAGES NONE)
 
 find_package(ROCM)
 

--- a/test/libsimple/CMakeLists.txt
+++ b/test/libsimple/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 
 cmake_minimum_required (VERSION 3.5)
-project(simple)
+project(simple CXX)
 
 find_package(ROCM)
 

--- a/test/libsimple2/CMakeLists.txt
+++ b/test/libsimple2/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 
 cmake_minimum_required (VERSION 3.5)
-project(simple2)
+project(simple2 CXX)
 
 find_package(ROCM)
 

--- a/test/libwrapper/CMakeLists.txt
+++ b/test/libwrapper/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 
 cmake_minimum_required (VERSION 3.5)
-project(test-wrapper)
+project(test-wrapper CXX)
 
 find_package(ROCM)
 

--- a/test/toolchain-var/CMakeLists.txt
+++ b/test/toolchain-var/CMakeLists.txt
@@ -5,8 +5,7 @@
 
 cmake_minimum_required (VERSION 3.5)
 find_package(ROCM)
-project(toolchain-var)
-enable_language(CXX)
+project(toolchain-var CXX)
 
 if(CHANGE_TOOLCHAIN)
 set(CMAKE_CXX_COMPILER gcc)

--- a/test/version/CMakeLists.txt
+++ b/test/version/CMakeLists.txt
@@ -3,7 +3,7 @@
 ################################################################################
 
 cmake_minimum_required (VERSION 3.5)
-project(simple)
+project(simple LANGUAGES NONE)
 
 find_package(ROCM)
 


### PR DESCRIPTION
Set the languages of the projects to NONE explicitly, to avoid CMake defaulting to C and C++.

From [CMake command project() documentation](https://cmake.org/cmake/help/latest/command/project.html?highlight=project):
> By default C and CXX are enabled if no language options are given

- This speeds up the configuration by a small amount because cmake does not have to search for and verify the compilers.
- It also allows configuring the project when a C orC++ compilers are not available.
- Finally when the build of rocm-cmake is embedded in an other project (as in the case of rocRAND) it avoids errors caused by cmake selecting MSVC for the C compiler but Clang for the C++ compiler on windows.