### PR TITLE
Use ${CMAKE_COMMAND} for running cmake from tests

### DIFF
--- a/test/pass/rocm-find-program-version.cmake
+++ b/test/pass/rocm-find-program-version.cmake
@@ -2,7 +2,7 @@ use_rocm_cmake()
 include(ROCMUtilities)
 
 rocm_find_program_version(
-    cmake
+    ${CMAKE_COMMAND}
     OUTPUT_VARIABLE test_version
 )
 
@@ -10,7 +10,7 @@ test_expect_eq("${test_version}" "${CMAKE_VERSION}")
 test_expect_eq("${test_version_OK}" TRUE)
 
 rocm_find_program_version(
-    cmake
+    ${CMAKE_COMMAND}
     OUTPUT_VARIABLE test_version
     GREATER_THAN "${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.0"
 )
@@ -18,7 +18,7 @@ rocm_find_program_version(
 test_expect_eq("${test_version_OK}" TRUE)
 
 rocm_find_program_version(
-    cmake
+    ${CMAKE_COMMAND}
     OUTPUT_VARIABLE test_version
     LESS "${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.0"
 )


### PR DESCRIPTION
Noticed this while working on #108.

The `rocm-find-program-version` test was failing at my machine because the cmake version I was using to configure rocm-cmake was not the first in my PATH.
Unlikely but possible would be that no cmake is found on the path at all, which would also lead to this test failing.

Use `${CMAKE_COMMAND}` that holds the full path to cmake to fix it.

Let me know If you think I should add this to #108, I felt like it was a separate issue.