### PR TITLE
ROCmCreatePackage: Update to prerm/postun scriptlets

### DIFF
--- a/share/rocm/cmake/ROCMCreatePackage.cmake
+++ b/share/rocm/cmake/ROCMCreatePackage.cmake
@@ -169,10 +169,16 @@ function(rocm_parse_python_syspath DIR_PATH PKG_NAME)
         }
         set_libdir
     ")
+    # Remove the path configuration files (.pth) only during remove/uninstall
+    # NOT during upgrade operation.
+    # Since same prerm scriptlet is used for both DEB and RPM pkgs, adding both
+    # conditions for rpm and deb scriptlets for remove case.
     file(APPEND ${PROJECT_BINARY_DIR}/debian/prerm
         "
         }
-        rm_libdir
+        if [ "$1" = "remove" ] || [ $1 -eq 0 ]; then
+            rm_libdir
+        fi
     ")
 endfunction()
 


### PR DESCRIPTION
During upgrade, the .pth files are getting removed after installing the new pkg( rpm/deb). This is because the postun/prerm scriplets has no condition check for remove/uninstall Vs upgrade.

THose .pth files should be removed only during the remove/uninstall operation.

Since the same set of scriptlets are used for both RPM and DEB, two conditions are checked for remove/uninstall and files will be removed on any one condition is satisfied ( either for RPM or DEB uninstall).

Signed-off-by: Saravanan Solaiyappan <saravanan.solaiyappan@amd.com>