### PR TITLE
Disable color for clang tidy cache file command

### DIFF
--- a/share/rocm/cmake/ROCMClangTidy.cmake
+++ b/share/rocm/cmake/ROCMClangTidy.cmake
@@ -197,7 +197,8 @@ function(rocm_clang_tidy_check TARGET)
                     set(CLANG_TIDY_COMMAND_LIST \"${CLANG_TIDY_COMMAND}\")
                     set(GH_ANNOTATIONS ${ROCM_ENABLE_GH_ANNOTATIONS})
                     execute_process(
-                        COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --target ${BASE_SOURCE}.i
+                        COMMAND
+                            ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --target ${BASE_SOURCE}.i -e COLOR=OFF
                         ERROR_QUIET
                         OUTPUT_VARIABLE PP_OUT
                         RESULT_VARIABLE RESULT1)


### PR DESCRIPTION
Color codes in the output of this command can cause the subsequent FILE(MD5 ...) commands to fail.