### PR TITLE
Revert "Changing #warning to #pragma message. (#89)"

### DIFF
--- a/share/rocm/cmake/header_template.h.in
+++ b/share/rocm/cmake/header_template.h.in
@@ -13,7 +13,7 @@
 #if defined(_MSC_VER)
 #pragma message(": warning:This file is deprecated. Use the header file from @header_location@ by using #include <@correct_include@>")
 #elif defined(__GNUC__)
-#pragma message(": warning : This file is deprecated. Use the header file from @header_location@ by using #include <@correct_include@>")
+#warning "This file is deprecated. Use the header file from @header_location@ by using #include <@correct_include@>"
 #endif
 /* include file */
 #define ROCM_@ITEM_GUARD@_GAVE_WARNING

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,10 +20,6 @@ foreach(TEST ${PASS_TESTS})
 endforeach()
 
 file(GLOB FAIL_TESTS fail/*.cmake)
-# Disable wrapper fail test, as the warning is changed to message
-# This is temporary and will be enabled back later when the behavior is reverted
-list(FILTER FAIL_TESTS EXCLUDE REGEX ".*wrapper\.cmake$")
-
 foreach(TEST ${FAIL_TESTS})
     get_filename_component(NAME ${TEST} NAME_WE)
     create_test(fail-${NAME} ${TEST})


### PR DESCRIPTION
We've had a couple releases as a message. It's time for this to become a warning.

Reverts RadeonOpenCompute/rocm-cmake#89.