### PR TITLE
Fix version-norepo and version-parent tests

### DIFF
--- a/test/pass/version-norepo.cmake
+++ b/test/pass/version-norepo.cmake
@@ -7,7 +7,7 @@ find_program(GIT NAMES git)
 # Try to test without git
 file(MAKE_DIRECTORY ${TMP_DIR}/repo)
 execute_process(
-    COMMAND ${GIT} describe --dirty --long --always
+    COMMAND ${GIT} describe --dirty --long --always --match [0-9]*
     WORKING_DIRECTORY ${TMP_DIR}/repo
     OUTPUT_VARIABLE GIT_TAG
     RESULT_VARIABLE RESULT)

--- a/test/pass/version-parent.cmake
+++ b/test/pass/version-parent.cmake
@@ -7,7 +7,7 @@ find_program(GIT NAMES git)
 # Try to test without git
 file(MAKE_DIRECTORY ${TMP_DIR}/repo)
 execute_process(
-    COMMAND ${GIT} describe --dirty --long --always
+    COMMAND ${GIT} describe --dirty --long --always --match [0-9]*
     WORKING_DIRECTORY ${TMP_DIR}/repo
     OUTPUT_VARIABLE GIT_TAG
     RESULT_VARIABLE RESULT)


### PR DESCRIPTION
This changes the tests to only match the numeric component, like the implementation of rocm_setup_version. Prior to these changes, the actual value would be the commit hash but the expected value would be the long output of git describe (containing the name of the nearest tag, the number of commits since that tag, and the commit hash). i.e.,

    expected: rocm-5.3.3-7-g8bc91a1
    actual: g8bc91a1

This changes it to be:

    expected: g8bc91a1
    actual: g8bc91a1

I still don't understand why this only recently began failing on the CI and I don't have a clear understanding of what these tests are testing.