### PR TITLE
Update changelog and bump version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [(Unreleased) rocm-cmake]
 ### Fixed
-- Added compatibility symlinks for included cmake files in `<ROCM>/lib/cmake/<PACAKGE>`.
+- ROCMInstallTargets: Added compatibility symlinks for included cmake files in `<ROCM>/lib/cmake/<PACKAGE>`.
 
 ## [rocm-cmake 0.8.0 for ROCm 5.4]
 ### Fixed
-- ROCmCreatePackage: Fixed error in prerm scripts that could break package upgrades when using the `PTH` option.
+- ROCMCreatePackage: Fixed error in prerm scripts that could break package upgrades when using the `PTH` option.
 - Removed unnecessary requirement for having C and C++ compilers available when building rocm-cmake from source.
 ### Known issues
 - This release did not have a unique version number.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log for rocm-cmake
 
+## [(Unreleased) rocm-cmake]
+### Fixed
+- Added compatibility symlinks for included cmake files in `<ROCM>/lib/cmake/<PACAKGE>`.
+
+## [rocm-cmake 0.8.0 for ROCm 5.4]
+### Fixed
+- ROCmCreatePackage: Fixed error in prerm scripts that could break package upgrades when using the `PTH` option.
+- Removed unnecessary requirement for having C and C++ compilers available when building rocm-cmake from source.
+### Known issues
+- This release did not have a unique version number.
+
 ## [rocm-cmake 0.8.0 for ROCm 5.3]
 ### Fixed
 - Fixed error in prerm scripts created by `rocm_create_package` that could break uninstall for packages using the `PTH` option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [(Unreleased) rocm-cmake]
 ### Fixed
 - ROCMInstallTargets: Added compatibility symlinks for included cmake files in `<ROCM>/lib/cmake/<PACKAGE>`.
+### Changed
+- ROCMHeaderWrapper: The wrapper header deprecation message is now a deprecation warning.
 
 ## [rocm-cmake 0.8.0 for ROCm 5.4]
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/share/rocm/cmake)
 include(ROCMCreatePackage)
 include(ROCMSetupVersion)
 
-rocm_setup_version(VERSION 0.8.0)
+rocm_setup_version(VERSION 0.8.1)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ROCMConfigVersion.cmake


### PR DESCRIPTION
Add changelog entries and bump the version number. The ROCm 5.4 release was the first we were trying to follow the new branching model. I don't think we clearly stated that we would follow the same versioning practices as other libraries, but I think it's a good idea to ensure that upon release, if the git hash is different then the version number is different.