### PR TITLE
Fix extra make flags passed for clang tidy

### DIFF
--- a/share/rocm/cmake/ROCMClangTidy.cmake
+++ b/share/rocm/cmake/ROCMClangTidy.cmake
@@ -217,7 +217,8 @@ function(rocm_clang_tidy_check TARGET)
                     set(GH_ANNOTATIONS ${ROCM_ENABLE_GH_ANNOTATIONS})
                     execute_process(
                         COMMAND
-                            ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --target ${BASE_SOURCE}.i -- -e COLOR=OFF
+                            ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --target ${BASE_SOURCE}.i --
+                            -e COLOR=OFF
                         ERROR_QUIET
                         OUTPUT_VARIABLE PP_OUT
                         RESULT_VARIABLE RESULT1)

--- a/share/rocm/cmake/ROCMClangTidy.cmake
+++ b/share/rocm/cmake/ROCMClangTidy.cmake
@@ -51,7 +51,9 @@ else()
     message(STATUS "Clang tidy found: ${CLANG_TIDY_VERSION}")
 endif()
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
+set(CMAKE_EXPORT_COMPILE_COMMANDS
+    ON
+    CACHE INTERNAL "")
 
 set(CLANG_TIDY_CACHE
     "${CMAKE_BINARY_DIR}/tidy-cache"
@@ -99,8 +101,7 @@ macro(rocm_enable_clang_tidy)
         string(REPLACE ";" "," CLANG_TIDY_ERRORS "${PARSE_ERRORS}")
 
         if(PARSE_UNPARSED_ARGUMENTS)
-            message(
-                FATAL_ERROR "Unknown keywords given to rocm_enable_clang_tidy(): \"${PARSE_UNPARSED_ARGUMENTS}\"")
+            message(FATAL_ERROR "Unknown keywords given to rocm_enable_clang_tidy(): \"${PARSE_UNPARSED_ARGUMENTS}\"")
         endif()
 
         message(STATUS "Clang tidy checks: ${CLANG_TIDY_CHECKS}")
@@ -293,7 +294,8 @@ function(rocm_clang_tidy_check TARGET)
                 ")
                 add_custom_target(
                     ${tidy_target}
-                    COMMAND ${CMAKE_COMMAND} ${CLANG_TIDY_DEV_WARNINGS_AS_ERRORS} -P ${CMAKE_CURRENT_BINARY_DIR}/${tidy_target}.cmake
+                    COMMAND ${CMAKE_COMMAND} ${CLANG_TIDY_DEV_WARNINGS_AS_ERRORS} -P
+                            ${CMAKE_CURRENT_BINARY_DIR}/${tidy_target}.cmake
                     COMMENT "clang-tidy: Running clang-tidy on target ${SOURCE}...")
             else()
                 add_custom_target(

--- a/share/rocm/cmake/ROCMClangTidy.cmake
+++ b/share/rocm/cmake/ROCMClangTidy.cmake
@@ -216,7 +216,7 @@ function(rocm_clang_tidy_check TARGET)
                     set(GH_ANNOTATIONS ${ROCM_ENABLE_GH_ANNOTATIONS})
                     execute_process(
                         COMMAND
-                            ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --target ${BASE_SOURCE}.i -e COLOR=OFF
+                            ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --target ${BASE_SOURCE}.i -- -e COLOR=OFF
                         ERROR_QUIET
                         OUTPUT_VARIABLE PP_OUT
                         RESULT_VARIABLE RESULT1)

--- a/test/analyze/CMakeLists.txt
+++ b/test/analyze/CMakeLists.txt
@@ -12,15 +12,9 @@ include(ROCMInstallTargets)
 include(ROCMAnalyzers)
 include(ROCMSetupVersion)
 
-rocm_setup_version(VERSION 1.0.0)
-
-configure_file(simple2.cpp.in simple2.cpp)
-
-add_library(simple simple.cpp ${CMAKE_CURRENT_BINARY_DIR}/simple2.cpp)
-rocm_install_targets(TARGETS simple INCLUDE include)
-
 include(ROCMClangTidy)
 rocm_enable_clang_tidy(
+    DEV_WARNINGS_AS_ERRORS
     CHECKS 
         *
         -llvmlibc-*
@@ -45,5 +39,13 @@ rocm_enable_cppcheck(
         findcasts
         threadsafety
 )
+
+rocm_setup_version(VERSION 1.0.0)
+
+configure_file(simple2.cpp.in simple2.cpp)
+
+add_library(simple simple.cpp ${CMAKE_CURRENT_BINARY_DIR}/simple2.cpp)
+rocm_install_targets(TARGETS simple INCLUDE include)
+
 
 rocm_clang_tidy_check(simple)


### PR DESCRIPTION
In newer cmake it doesn't implicitly pass the flags along(this seemed to be an undocumented feature). Either way, I added `--` to fix this. 

Also, updated the tests to find these issues in the future. 