### PR TITLE
Update version number and changelog for ROCm 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log for rocm-cmake
 
+## [rocm-cmake 0.11.0 for ROCm 6.0.0]
+### Changed
+- ROCMSphinxDoc: Improved validation, documentation and rocm-docs-core integration.
+### Fixed
+- ROCMClangTidy: Fixed extra make flags passed for clang tidy.
+- ROCMTest: Fixed issues when using module in a subdirectory.
+
 ## [rocm-cmake 0.10.0 for ROCm 5.7.0]
 ### Added
 - Added ROCMTest module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/share/rocm/cmake)
 include(ROCMCreatePackage)
 include(ROCMSetupVersion)
 
-rocm_setup_version(VERSION 0.10.0)
+rocm_setup_version(VERSION 0.11.0)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ROCMConfigVersion.cmake


### PR DESCRIPTION
We should probably have done this sooner, but better late than never.