### PR TITLE
Allow separate source and config dirs in sphinx

### DIFF
--- a/doc/src/ROCMSphinxDoc.rst
+++ b/doc/src/ROCMSphinxDoc.rst
@@ -12,6 +12,7 @@ Commands
         SRC_DIR
         BUILDER <sphinx-builder>
         [OUTPUT_DIR <output-directory>]
+        [CONFIG_DIR <config-directory>]
         [DEPENDS <doc-targets>...]
         [VARS <sphinx-variables>...]
         [TEMPLATE_VARS <sphinx-variables>...]
@@ -28,6 +29,12 @@ The options are:
   The directory where build output will be written. It takes its default, from
   ``ROCM_CMAKE_DOCS_DIR`` if set, otherwise defaults to ``sphinx/${BUILDER}``.
   Relative paths are interpreted relative to ``CMAKE_CURRENT_BINARY_DIR``.
+
+``CONFIG_DIR``
+  The directory where ``conf.py`` will be searched. It sets the ``-c`` argument
+  of ``sphinx-build`` if set, otherwise defaults to ``${SRC_DIR}`` as per the
+  underlying tool. Relative paths are interpreted relative to
+  ``CMAKE_CURRENT_SOURCE_DIR``.
 
 ``DEPENDS``
   Sets up target-level dependencies between ``sphinx-${BUILDER}`` and the

--- a/share/rocm/cmake/ROCMSphinxDoc.cmake
+++ b/share/rocm/cmake/ROCMSphinxDoc.cmake
@@ -27,13 +27,13 @@ mark_as_advanced(DOXYGEN_EXECUTABLE)
 
 function(rocm_add_sphinx_doc SRC_DIR)
     set(options USE_DOXYGEN)
-    set(oneValueArgs BUILDER OUTPUT_DIR)
+    set(oneValueArgs BUILDER CONFIG_DIR OUTPUT_DIR)
     set(multiValueArgs DEPENDS VARS TEMPLATE_VARS)
 
     cmake_parse_arguments(PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     get_filename_component(SRC_DIR "${SRC_DIR}" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-    if(NOT EXISTS "${SRC_DIR}/conf.py")
+    if(NOT PARSE_CONFIG_DIR AND NOT EXISTS "${SRC_DIR}/conf.py")
         message(FATAL_ERROR "rocm_add_sphinx_doc cannot find ${SRC_DIR}/conf.py")
     endif()
 
@@ -51,6 +51,16 @@ function(rocm_add_sphinx_doc SRC_DIR)
         else()
             set(OUTPUT_DIR "sphinx/${PARSE_BUILDER}")
         endif()
+    endif()
+
+    if(PARSE_CONFIG_DIR)
+        if(NOT EXISTS "${PARSE_CONFIG_DIR}/conf.py")
+            message(FATAL_ERROR "rocm_add_sphinx_doc cannot find ${PARSE_CONFIG_DIR}/conf.py")
+        endif()
+        get_filename_component(CONFIG_DIR "${PARSE_CONFIG_DIR}" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+        set(CONFIG_DIR_ARG -c "${CONFIG_DIR}")
+    else()
+        set(CONFIG_DIR_ARG)
     endif()
 
     set(VARS)
@@ -79,6 +89,7 @@ function(rocm_add_sphinx_doc SRC_DIR)
         ${PROJECT_NAME}-sphinx-${BUILDER}
         COMMAND
             "${SPHINX_EXECUTABLE}"
+            ${CONFIG_DIR_ARG}
             -b ${PARSE_BUILDER}
             -d "${CMAKE_CURRENT_BINARY_DIR}/doctrees"
             ${USES_DOXYGEN}


### PR DESCRIPTION
rocm-docs-core up until now assumed that during Sphinx documentation build the configure and source directories were the same. To allow use cases where project maintainers don't want to litter the source tree with build side-effects (understandable), this assumption is being cleaned up within rocm-docs-code (see [here](https://github.com/RadeonOpenCompute/rocm-docs-core/pull/409)).

This is the rocm-cmake side of supporting such use cases, allowing setting the `-c` flag of Sphinx. `conf.py` is searched either within this folder, or if not set, within the source tree, as was the case until now.