### PR TITLE
[ROCM 5.7] fix default installation path on Windows

### DIFF
--- a/share/rocm/cmake/ROCMHeaderWrapper.cmake
+++ b/share/rocm/cmake/ROCMHeaderWrapper.cmake
@@ -81,8 +81,6 @@ ${file_contents}
         else()
             if(NOT WIN32)
                 set(HEADER_INSTALL_PREFIX "/usr/local")
-            else()
-                set(HEADER_INSTALL_PREFIX "c:/Program Files/${PROJECT_NAME}")
             endif()
         endif()
         get_filename_component(header_location "${PARSE_HEADER_LOCATION}/${INCLUDE_FILE}"


### PR DESCRIPTION
The PR is for the 5.7 branch because we need it for the ROCm 5.7 release on Windows.

It is unusual on Windows to install to `C:\Program Files` manually. It requires Administrator privilege, which is not standard or not easily granted. Only applications managed by the Windows installer are allowed to install in that directory, and `cmake install` is not one of them.
Installing tests in a custom directory given to CMake is also impossible when `HEADER_INSTALL_PREFIX` is set to `C:/Program Files`. Moreover, the directory `C:\Program Files` is for 64-bit applications only. In the case of 32-bit, the installer should use the `C:\Program Files (x86)` directory instead.

The separate PRs will add that change to the current development branch.