### PR TITLE
Allow additional provides on header-only packages

### DIFF
--- a/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
@@ -336,8 +336,14 @@ macro(rocm_create_package)
             )
         endif()
         if(PARSE_HEADER_ONLY)
-            set(CPACK_DEBIAN_DEVEL_PACKAGE_PROVIDES "${CPACK_PACKAGE_NAME} (= ${CPACK_PACKAGE_VERSION})")
-            set(CPACK_RPM_DEVEL_PACKAGE_PROVIDES "${CPACK_PACKAGE_NAME} = ${CPACK_PACKAGE_VERSION}")
+            rocm_join_if_set(", "
+                CPACK_DEBIAN_DEVEL_PACKAGE_PROVIDES
+                CPACK_DEBIAN_PACKAGE_PROVIDES
+                "${CPACK_PACKAGE_NAME} (= ${CPACK_PACKAGE_VERSION})")
+            rocm_join_if_set(", "
+                CPACK_RPM_DEVEL_PACKAGE_PROVIDES
+                CPACK_DEBIAN_PACKAGE_PROVIDES
+                "${CPACK_PACKAGE_NAME} = ${CPACK_PACKAGE_VERSION}")
         else()
             rocm_package_add_dependencies(COMPONENT devel DEPENDS "${CPACK_PACKAGE_NAME} >= ${CPACK_PACKAGE_VERSION}")
         endif()


### PR DESCRIPTION
Header-only components set the "Provides" field of the generated packages so that installation of e.g. `rocthrust` installs the expected package `rocthrust-dev[el]`. However the previous implementation overwrote any previous values for the `PROVIDES` field, this should now be resolved. 