### PR TITLE
Disable docsphinx test on macOS

### DIFF
--- a/test/pass/doc-sphinxdoxygen.cmake
+++ b/test/pass/doc-sphinxdoxygen.cmake
@@ -2,7 +2,9 @@
 # Copyright (C) 2023 Advanced Micro Devices, Inc.
 # ######################################################################################################################
 
-install_dir(${TEST_DIR}/docsphinx TARGETS doc install)
-test_expect_installed_file(
-    share/doc/useful/html/index.html
-    share/doc/useful/html/reference.html)
+if(NOT APPLE)
+    install_dir(${TEST_DIR}/docsphinx TARGETS doc install)
+    test_expect_installed_file(
+        share/doc/useful/html/index.html
+        share/doc/useful/html/reference.html)
+endif()


### PR DESCRIPTION
Temporary workaround for #166, disables the doc-sphinxdoxygen test on macOS until the linked issue can be resolved.