### PR TITLE
Rename check target to rocm-cmake-check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
     - mkdir build
     - cd build
     - cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX_PATH ..
-    - make check
+    - make rocm-cmake-check
     - make install
     - rm -rf "$INSTALL_PREFIX_PATH"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,6 @@ add_custom_target(analyze COMMAND cmake-lint ${CMAKE_FILES} WORKING_DIRECTORY ${
 add_custom_target(format COMMAND cmake-format -i ${CMAKE_FILES} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 enable_testing()
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
+add_custom_target(rocm-cmake-check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
 add_subdirectory(test)
 add_subdirectory(docs)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ build_script:
  - cmd: mkdir build
  - cmd: cd build
  - cmd: cmake .. -G"%GENERATOR%"
- - cmd: cmake --build . --config %CONFIG% --target check
+ - cmd: cmake --build . --config %CONFIG% --target rocm-cmake-check
 
 # test_script:
 #  - cmd: ctest -C Debug --output-on-failure

--- a/share/rocmcmakebuildtools/cmake/ROCMTest.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMTest.cmake
@@ -14,10 +14,10 @@ set(CTEST_PARALLEL_LEVEL
 set(CTEST_TIMEOUT
     5000
     CACHE STRING "CTest timeout")
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -j ${CTEST_PARALLEL_LEVEL} -C
+add_custom_target(rocm-cmake-check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -j ${CTEST_PARALLEL_LEVEL} -C
                                 ${CMAKE_CFG_INTDIR} --timeout ${CTEST_TIMEOUT})
 add_custom_target(tests COMMENT "Build all tests.")
-add_dependencies(check tests)
+add_dependencies(rocm-cmake-check tests)
 
 add_custom_target(install-tests COMMAND ${CMAKE_COMMAND} -DCOMPONENT=tests -P ${CMAKE_BINARY_DIR}/cmake_install.cmake)
 add_dependencies(install-tests tests)

--- a/test/pass/simple-test.cmake
+++ b/test/pass/simple-test.cmake
@@ -2,6 +2,6 @@
 # Copyright (C) 2023 Advanced Micro Devices, Inc.
 # ######################################################################################################################
 
-install_dir(${TEST_DIR}/libsimpletest TARGETS check install-tests)
+install_dir(${TEST_DIR}/libsimpletest TARGETS rocm-cmake-check install-tests)
 test_expect_file(${PREFIX}/share/test/simple/CTestTestfile.cmake)
 test_exec(COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure WORKING_DIRECTORY ${PREFIX}/share/test/simple)


### PR DESCRIPTION
This is so that we can add_subdirectory() this project and not clash with LLVM's check target.

TEST: running before and after has same number of check failures (3) on my system