### PR TITLE
Turn off ROCM_SYMLINK_LIBS by default

### DIFF
--- a/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
@@ -116,7 +116,7 @@ function(rocm_install)
     endif()
 endfunction()
 
-option(ROCM_SYMLINK_LIBS "Create backwards compatibility symlink for library files." ON)
+option(ROCM_SYMLINK_LIBS "Create backwards compatibility symlink for library files." OFF)
 
 function(rocm_install_targets)
     set(options PRIVATE)


### PR DESCRIPTION
This PR turns off ROCM_SYMLINK_LIBS off by default. 