### PR TITLE
HOTFIX: Correct ordering of suffixes

### DIFF
--- a/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
@@ -500,13 +500,13 @@ macro(rocm_compute_component_package_name COMPONENT_NAME BASE_NAME NAME_SUFFIX H
         OR CPACK_RPM_${_component_name_upper}_PACKAGE_NAME STREQUAL ""
     )
         set(CPACK_RPM_${_component_name_upper}_PACKAGE_NAME
-            "${BASE_NAME}${_rpm_component_partial}${_component_suffix}")
+            "${BASE_NAME}${_component_suffix}${_rpm_component_partial}")
     endif()
     if(NOT DEFINED CPACK_DEBIAN_${_component_name_upper}_PACKAGE_NAME
         OR CPACK_DEBIAN_${_component_name_upper}_PACKAGE_NAME STREQUAL ""
     )
         set(CPACK_DEBIAN_${_component_name_upper}_PACKAGE_NAME
-            "${BASE_NAME}${_deb_component_partial}${_component_suffix}")
+            "${BASE_NAME}${_component_suffix}${_deb_component_partial}")
     endif()
 
     # clean up temporary variables


### PR DESCRIPTION
This commit was missed when cherry-picking into the release-staging branch, which was noticed too late before creating the release branch.

(cherry picked from commit bd28d0fbebfe4026687360adff43e981e34db844)