### PR TITLE
Fix names for header-only components when built statically

### DIFF
--- a/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
@@ -475,7 +475,7 @@ macro(rocm_compute_component_package_name COMPONENT_NAME BASE_NAME NAME_SUFFIX H
     else()
         if(ENABLE_ASAN_PACKAGING)
             set(_component_suffix asan)
-        elseif(NOT ${HEADER_ONLY} AND NOT ${BUILD_SHARED_LIBS})
+        elseif(NOT ${BUILD_SHARED_LIBS})
             set(_component_suffix static)
         endif()
     endif()


### PR DESCRIPTION
Statically built packages may have different dependencies than the non-static packages, even for header only components whose contents are otherwise identical. As such, the generated packages should have separate names.