### PR TITLE
Update `macos` runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         platform:
           - ubuntu-20.04
-          - macos-11
+          - macos-12
           - windows-2019
         cmake-version:
           - 3.20.0


### PR DESCRIPTION
The `macos-11` runner is deprecated by GitHub: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/ We should switch to a later `macos` runner, I have selected 12 here