### PR TITLE
Set the correct include directory on interface target

### DIFF
--- a/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
@@ -177,7 +177,7 @@ function(rocm_install_targets)
                 target_include_directories(${TARGET} PRIVATE ${INCLUDE_PATH})
             endif()
         endforeach()
-        target_include_directories(${TARGET} INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
+        target_include_directories(${TARGET} INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INCLUDE_INSTALL_DIR}>)
     endforeach()
 
     set(runtime "runtime")


### PR DESCRIPTION
When installing `PRIVATE` targets the include path is not `$<INSTALL_PREFIX>/include`, so we need to use the `INCLUDE_INSTALL_DIR` variable.