### PR TITLE
Avoid dev package recommends/suggestion for ASAN

### DIFF
--- a/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
@@ -327,6 +327,7 @@ macro(rocm_create_package)
         rocm_compute_component_package_name(devel "${CPACK_PACKAGE_NAME}" "${PARSE_SUFFIX}" "${PARSE_HEADER_ONLY}")
         list(APPEND PARSE_COMPONENTS devel)
         if(NOT ENABLE_ASAN_PACKAGING)
+            # Since no asan-dev package available, avoid recommends/suggests
             rocm_join_if_set(", " CPACK_DEBIAN_RUNTIME_PACKAGE_RECOMMENDS
                 "${CPACK_DEBIAN_DEVEL_PACKAGE_NAME} (>=${CPACK_PACKAGE_VERSION})")
         endif()
@@ -334,6 +335,7 @@ macro(rocm_create_package)
         rocm_find_program_version(rpmbuild GREATER_EQUAL 4.12.0 QUIET)
         if(rpmbuild_VERSION_OK)
             if(NOT ENABLE_ASAN_PACKAGING)
+                # Since no asan-dev package available, avoid recommends/suggests
                 rocm_join_if_set(", " CPACK_RPM_RUNTIME_PACKAGE_SUGGESTS
                     "${CPACK_RPM_DEVEL_PACKAGE_NAME} >= ${CPACK_PACKAGE_VERSION}"
                 )

--- a/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
@@ -326,14 +326,18 @@ macro(rocm_create_package)
     if (ROCM_USE_DEV_COMPONENT)
         rocm_compute_component_package_name(devel "${CPACK_PACKAGE_NAME}" "${PARSE_SUFFIX}" "${PARSE_HEADER_ONLY}")
         list(APPEND PARSE_COMPONENTS devel)
-        rocm_join_if_set(", " CPACK_DEBIAN_RUNTIME_PACKAGE_RECOMMENDS
-            "${CPACK_DEBIAN_DEVEL_PACKAGE_NAME} (>=${CPACK_PACKAGE_VERSION})")
+        if(NOT ENABLE_ASAN_PACKAGING)
+            rocm_join_if_set(", " CPACK_DEBIAN_RUNTIME_PACKAGE_RECOMMENDS
+                "${CPACK_DEBIAN_DEVEL_PACKAGE_NAME} (>=${CPACK_PACKAGE_VERSION})")
+        endif()
 
         rocm_find_program_version(rpmbuild GREATER_EQUAL 4.12.0 QUIET)
         if(rpmbuild_VERSION_OK)
-            rocm_join_if_set(", " CPACK_RPM_RUNTIME_PACKAGE_SUGGESTS
-                "${CPACK_RPM_DEVEL_PACKAGE_NAME} >= ${CPACK_PACKAGE_VERSION}"
-            )
+            if(NOT ENABLE_ASAN_PACKAGING)
+                rocm_join_if_set(", " CPACK_RPM_RUNTIME_PACKAGE_SUGGESTS
+                    "${CPACK_RPM_DEVEL_PACKAGE_NAME} >= ${CPACK_PACKAGE_VERSION}"
+                )
+            endif()
         endif()
         if(PARSE_HEADER_ONLY OR NOT BUILD_SHARED_LIBS)
             if(DEFINED CPACK_DEBIAN_DEVEL_PACKAGE_PROVIDES)

--- a/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMCreatePackage.cmake
@@ -326,20 +326,19 @@ macro(rocm_create_package)
     if (ROCM_USE_DEV_COMPONENT)
         rocm_compute_component_package_name(devel "${CPACK_PACKAGE_NAME}" "${PARSE_SUFFIX}" "${PARSE_HEADER_ONLY}")
         list(APPEND PARSE_COMPONENTS devel)
-        if(NOT ENABLE_ASAN_PACKAGING)
-            # Since no asan-dev package available, avoid recommends/suggests
+        if (NOT ENABLE_ASAN_PACKAGING)
+            # Since no asan-dev package available, avoid recommends for ASAN
             rocm_join_if_set(", " CPACK_DEBIAN_RUNTIME_PACKAGE_RECOMMENDS
-                "${CPACK_DEBIAN_DEVEL_PACKAGE_NAME} (>=${CPACK_PACKAGE_VERSION})")
+                "${CPACK_DEBIAN_DEVEL_PACKAGE_NAME} (>=${CPACK_PACKAGE_VERSION})"
+            )
         endif()
 
         rocm_find_program_version(rpmbuild GREATER_EQUAL 4.12.0 QUIET)
-        if(rpmbuild_VERSION_OK)
-            if(NOT ENABLE_ASAN_PACKAGING)
-                # Since no asan-dev package available, avoid recommends/suggests
-                rocm_join_if_set(", " CPACK_RPM_RUNTIME_PACKAGE_SUGGESTS
-                    "${CPACK_RPM_DEVEL_PACKAGE_NAME} >= ${CPACK_PACKAGE_VERSION}"
-                )
-            endif()
+        if(rpmbuild_VERSION_OK AND NOT ENABLE_ASAN_PACKAGING)
+            # Since no asan-dev package available, avoid suggests for ASAN
+            rocm_join_if_set(", " CPACK_RPM_RUNTIME_PACKAGE_SUGGESTS
+                "${CPACK_RPM_DEVEL_PACKAGE_NAME} >= ${CPACK_PACKAGE_VERSION}"
+            )
         endif()
         if(PARSE_HEADER_ONLY OR NOT BUILD_SHARED_LIBS)
             if(DEFINED CPACK_DEBIAN_DEVEL_PACKAGE_PROVIDES)


### PR DESCRIPTION
**Proposed Changes:**
- Since there are no <pkgnm>-**asan-dev** available, Avoid suggests/recommends 
- Currently we are adding recommends for asan pkgs as an example for <pkg>-asan we have
Recommends: <pkg>-asan-dev (>=2.21.5.60300) (but this package not exists)
- Proposed change will remove this recommends/Suggests to unavailable <pkgnm>-asan-dev package.

