### PR TITLE
Hint the location of dependencies

### DIFF
--- a/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
@@ -315,7 +315,7 @@ function(rocm_write_package_deps CONFIG_TEMPLATE)
     set(DEPENDS ${ARGN})
     rocm_list_split(DEPENDS PACKAGE DEPENDS_LIST)
     foreach(DEPEND ${DEPENDS_LIST})
-        rocm_write_package_template_function(${CONFIG_TEMPLATE} find_dependency ${${DEPEND}})
+        rocm_write_package_template_function(${CONFIG_TEMPLATE} find_dependency ${${DEPEND}} HINTS "\"\${PACKAGE_PREFIX_DIR}\"")
     endforeach()
 endfunction()
 

--- a/share/rocmcmakebuildtools/cmake/ROCMPackageConfigHelpers.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMPackageConfigHelpers.cmake
@@ -87,10 +87,6 @@ include(CMakeFindDependencyMacro OPTIONAL RESULT_VARIABLE _ROCMCMakeFindDependen
 if (NOT _ROCMCMakeFindDependencyMacro_FOUND)
     macro(find_dependency dep)
         if (NOT \${dep}_FOUND)
-            set(rocm_fd_version)
-            if (\${ARGC} GREATER 1)
-                set(rocm_fd_version \${ARGV1})
-            endif()
             set(rocm_fd_exact_arg)
             if(\${CMAKE_FIND_PACKAGE_NAME}_FIND_VERSION_EXACT)
                 set(rocm_fd_exact_arg EXACT)
@@ -103,11 +99,10 @@ if (NOT _ROCMCMakeFindDependencyMacro_FOUND)
             if(\${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED)
                 set(rocm_fd_required_arg REQUIRED)
             endif()
-            find_package(\${dep} \${rocm_fd_version}
+            find_package(\${dep} \${ARGN}
                 \${rocm_fd_exact_arg}
                 \${rocm_fd_quiet_arg}
                 \${rocm_fd_required_arg}
-                HINTS \"\${PACKAGE_PREFIX_DIR}\"
             )
             string(TOUPPER \${dep} cmake_dep_upper)
             if (NOT \${dep}_FOUND AND NOT \${cmake_dep_upper}_FOUND)

--- a/share/rocmcmakebuildtools/cmake/ROCMPackageConfigHelpers.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMPackageConfigHelpers.cmake
@@ -107,6 +107,7 @@ if (NOT _ROCMCMakeFindDependencyMacro_FOUND)
                 \${rocm_fd_exact_arg}
                 \${rocm_fd_quiet_arg}
                 \${rocm_fd_required_arg}
+                HINTS \"\${PACKAGE_PREFIX_DIR}\"
             )
             string(TOUPPER \${dep} cmake_dep_upper)
             if (NOT \${dep}_FOUND AND NOT \${cmake_dep_upper}_FOUND)


### PR DESCRIPTION
If a ROCm package knows its installed under PACKAGE_PREFIX_DIR, it should search under that project prefix for related dependencies.

This prevents users from having to add that prefix to their CMake module, path, which is a known antipattern.