### PR TITLE
Allow suppression of warnings in ROCMChecks

### DIFF
--- a/share/rocmcmakebuildtools/cmake/ROCMChecks.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMChecks.cmake
@@ -44,8 +44,8 @@ function(rocm_check_toolchain_var var access value list_file)
   calling 'cmake -D${var}=\"${value}\"'
   or set in a toolchain file and added with
   'cmake -DCMAKE_TOOLCHAIN_FILE=<toolchain-file>'. ROCMChecks now calling:")
-            message(${message_type} "'${var}' is set at ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt:<line#> shown below:")
-            message( "*-----------------------------------------------------------------------------*
+                message(${message_type} "'${var}' is set at ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt:<line#> below:")
+                message( "*-----------------------------------------------------------------------------*
 *******************************************************************************
 ")
             endif()

--- a/share/rocmcmakebuildtools/cmake/ROCMChecks.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMChecks.cmake
@@ -25,17 +25,18 @@ function(rocm_check_toolchain_var var access value list_file)
         set(message_type WARNING)
         set(message_title "ROCMChecks WARNING")
     endif()
-    if(access STREQUAL "MODIFIED_ACCESS")
-        set(cmake_module Off)
-        get_filename_component(base "${list_file}" DIRECTORY)
-        # Skip warning in cmake's built-in modules
-        if("${base}" STREQUAL "${CMAKE_ROOT}/Modules")
-            set(cmake_module On)
-        elseif("${base}" MATCHES ".*/CMakeFiles/${CMAKE_VERSION}$")
-            set(cmake_module On)
-        endif()
-        if(NOT cmake_module)
-            message( "
+    if(ROCM_WARN_TOOLCHAIN_VAR OR ROCM_ERROR_TOOLCHAIN_VAR)
+        if(access STREQUAL "MODIFIED_ACCESS")
+            set(cmake_module Off)
+            get_filename_component(base "${list_file}" DIRECTORY)
+            # Skip warning in cmake's built-in modules
+            if("${base}" STREQUAL "${CMAKE_ROOT}/Modules")
+                set(cmake_module On)
+            elseif("${base}" MATCHES ".*/CMakeFiles/${CMAKE_VERSION}$")
+                set(cmake_module On)
+            endif()
+            if(NOT cmake_module)
+                message( "
 *******************************************************************************
 *------------------------------- ${message_title} --------------------------*
   Options and properties should be set on a cmake target where possible. The
@@ -47,6 +48,7 @@ function(rocm_check_toolchain_var var access value list_file)
             message( "*-----------------------------------------------------------------------------*
 *******************************************************************************
 ")
+            endif()
         endif()
     endif()
 endfunction()


### PR DESCRIPTION
## Motivation

Warnings caused by third-party dependencies that are out of the control of a project cannot be suppressed and clutter the build output. 

## Technical Details

Only adds the warning statement if either ROCM_WARN_TOOLCHAIN_VAR or ROCM_ERROR_TOOLCHAIN_VAR are set, which enables nesting dependency fetches inside of scoped `block` calls to suppress warnings found by ROCMChecks.

## Test Plan

Standard CI testing. Manual function testing for hipblaslt confirms this pattern's validity.

## Test Result

Warnings are properly suppressed when ROCM_WARN_TOOLCHAIN_VAR is set to OFF.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
