### PR TITLE
Test: Use clang-cl instead of clang++ on Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,13 @@ jobs:
       run: |
         echo "CC=clang" >> $GITHUB_ENV
         echo "CXX=clang++" >> $GITHUB_ENV
+        echo "CFLAGS=-gcodeview" >> $GITHUB_ENV
+        echo "CXXFLAGS=-gcodeview" >> $GITHUB_ENV
+        echo "LDFLAGS=-fuse-ld=lld-link /DEBUG" >> $GITHUB_ENV
+
+    - name: Setup MSVC for Ninja
+      if: matrix.platform == 'windows-2022' && matrix.compiler == 'default'
+      uses: ilammy/msvc-dev-cmd@v1
 
     - name: Cmake version
       run: cmake --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,12 +82,12 @@ jobs:
         version: "20"
         directory: ${{ runner.temp }}/llvm
 
-    - name: Setup clang++
+    - name: Setup clang-cl
       if: matrix.compiler == 'clang'
       shell: bash
       run: |
-        echo "CC=clang" >> $GITHUB_ENV
-        echo "CXX=clang++" >> $GITHUB_ENV
+        echo "CC=clang-cl" >> $GITHUB_ENV
+        echo "CXX=clang-cl" >> $GITHUB_ENV
 
     - name: Cmake version
       run: cmake --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,16 +82,12 @@ jobs:
         version: "20"
         directory: ${{ runner.temp }}/llvm
 
-    - name: Setup clang-cl
+    - name: Setup clang++
       if: matrix.compiler == 'clang'
       shell: bash
       run: |
-        echo "CC=clang-cl" >> $GITHUB_ENV
-        echo "CXX=clang-cl" >> $GITHUB_ENV
-
-    - name: Setup MSVC for Ninja
-      if: matrix.platform == 'windows-2022' && matrix.compiler == 'default'
-      uses: ilammy/msvc-dev-cmd@v1
+        echo "CC=clang" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV
 
     - name: Cmake version
       run: cmake --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,10 @@ jobs:
         echo "CC=clang-cl" >> $GITHUB_ENV
         echo "CXX=clang-cl" >> $GITHUB_ENV
 
+    - name: Setup MSVC for Ninja
+      if: matrix.platform == 'windows-2022' && matrix.compiler == 'default'
+      uses: ilammy/msvc-dev-cmd@v1
+
     - name: Cmake version
       run: cmake --version
 

--- a/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
@@ -234,6 +234,8 @@ function(rocm_install_targets)
                 COMPONENT ${development}
         )
         if(WIN32 AND
+            (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC" OR
+             CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC") AND
             (T_TYPE STREQUAL "SHARED_LIBRARY" OR
              T_TYPE STREQUAL "MODULE_LIBRARY" OR
              T_TYPE STREQUAL "EXECUTABLE"))

--- a/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
@@ -234,8 +234,6 @@ function(rocm_install_targets)
                 COMPONENT ${development}
         )
         if(WIN32 AND
-            (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC" OR
-             CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC") AND
             (T_TYPE STREQUAL "SHARED_LIBRARY" OR
              T_TYPE STREQUAL "MODULE_LIBRARY" OR
              T_TYPE STREQUAL "EXECUTABLE"))

--- a/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
@@ -233,7 +233,7 @@ function(rocm_install_targets)
                 DESTINATION ${LIB_INSTALL_DIR}
                 COMPONENT ${development}
         )
-        if(WIN32 AND MSVC AND
+        if(WIN32 AND
             (T_TYPE STREQUAL "SHARED_LIBRARY" OR
              T_TYPE STREQUAL "MODULE_LIBRARY" OR
              T_TYPE STREQUAL "EXECUTABLE"))

--- a/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
@@ -233,6 +233,13 @@ function(rocm_install_targets)
                 DESTINATION ${LIB_INSTALL_DIR}
                 COMPONENT ${development}
         )
+        if(WIN32 AND
+            (T_TYPE STREQUAL "SHARED_LIBRARY" OR
+             T_TYPE STREQUAL "MODULE_LIBRARY" OR
+             T_TYPE STREQUAL "EXECUTABLE"))
+            install(FILES $<TARGET_PDB_FILE:${TARGET}>
+                DESTINATION ${BIN_INSTALL_DIR} OPTIONAL)
+        endif()
         rocm_set_install_dir_property(
             TARGETS ${TARGET}
             RUNTIME_DESTINATION ${BIN_INSTALL_DIR}

--- a/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
+++ b/share/rocmcmakebuildtools/cmake/ROCMInstallTargets.cmake
@@ -233,7 +233,7 @@ function(rocm_install_targets)
                 DESTINATION ${LIB_INSTALL_DIR}
                 COMPONENT ${development}
         )
-        if(WIN32 AND
+        if(WIN32 AND MSVC AND
             (T_TYPE STREQUAL "SHARED_LIBRARY" OR
              T_TYPE STREQUAL "MODULE_LIBRARY" OR
              T_TYPE STREQUAL "EXECUTABLE"))


### PR DESCRIPTION
## Summary
- Test switching Windows Clang CI from clang++ (GNU-like) to clang-cl (MSVC-compatible) so PDB files are generated

## Test plan
- [ ] Verify Windows CI passes with clang-cl