### PR TITLE
Pin Actions to commit SHAs and add Dependabot scanning for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,15 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "pfultz2"
+      - "lawruble13"
+      - "cgmb"
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/docs" # Location of package manifests
     open-pull-requests-limit: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,20 +2,17 @@ name: rocm-cmake
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  cancel:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
   lint:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.10"
     - name: Install dependencies
@@ -52,13 +49,13 @@ jobs:
             compiler: clang
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.10"
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.9
+      uses: jwlawson/actions-setup-cmake@710e05536f2b819d5918f51a5de5b392e99bba3c # v1.9
       with:
         cmake-version: ${{ matrix.cmake-version }}
     - name: Install dependencies
@@ -67,7 +64,7 @@ jobs:
         python -m pip install cget ninja
         python -m pip install -r docs/requirements.txt
     - name: Install Doxygen
-      uses: ssciwr/doxygen-install@v1
+      uses: ssciwr/doxygen-install@f13be1686235deee0aeb6cdf56640170691dc96b # v1
       with:
         version: "1.10.0"
     - name: Setup git
@@ -77,7 +74,7 @@ jobs:
 
     - name: Install LLVM/Clang
       if: matrix.compiler == 'clang'
-      uses: KyleMayes/install-llvm-action@v2
+      uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
       with:
         version: "20"
         directory: ${{ runner.temp }}/llvm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.10
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.10
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
@@ -26,6 +28,7 @@ jobs:
   test:
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       max-parallel: 4
       matrix:
         platform:

--- a/test/pass/version-parent.cmake
+++ b/test/pass/version-parent.cmake
@@ -4,8 +4,13 @@
 
 find_program(GIT NAMES git)
 
-# Try to test without git
 file(MAKE_DIRECTORY ${TMP_DIR}/repo)
+test_exec(COMMAND ${GIT} init WORKING_DIRECTORY ${TMP_DIR}/repo)
+foreach(I RANGE 10)
+    file(WRITE ${TMP_DIR}/repo/dummy.txt "commit ${I}")
+    test_exec(COMMAND ${GIT} add dummy.txt WORKING_DIRECTORY ${TMP_DIR}/repo)
+    test_exec(COMMAND ${GIT} commit -m "commit ${I}" WORKING_DIRECTORY ${TMP_DIR}/repo)
+endforeach()
 execute_process(
     COMMAND ${GIT} describe --dirty --long --always --match [0-9]*
     WORKING_DIRECTORY ${TMP_DIR}/repo
@@ -19,9 +24,9 @@ execute_process(
     WORKING_DIRECTORY ${TMP_DIR}/repo
     OUTPUT_VARIABLE REVS
     RESULT_VARIABLE RESULT)
-separate_arguments(REVS UNIX_COMMAND "${REVS}")
-list(GET REVS 10 PARENT)
 string(STRIP "${REVS}" REVS)
+string(REPLACE "\n" ";" REVS "${REVS}")
+list(GET REVS 10 PARENT)
 message("PARENT: ${PARENT}")
 write_version_cmake(
     ${TMP_DIR}/repo

--- a/test/pass/version-parent.cmake
+++ b/test/pass/version-parent.cmake
@@ -4,13 +4,8 @@
 
 find_program(GIT NAMES git)
 
+# Try to test without git
 file(MAKE_DIRECTORY ${TMP_DIR}/repo)
-test_exec(COMMAND ${GIT} init WORKING_DIRECTORY ${TMP_DIR}/repo)
-foreach(I RANGE 10)
-    file(WRITE ${TMP_DIR}/repo/dummy.txt "commit ${I}")
-    test_exec(COMMAND ${GIT} add dummy.txt WORKING_DIRECTORY ${TMP_DIR}/repo)
-    test_exec(COMMAND ${GIT} commit -m "commit ${I}" WORKING_DIRECTORY ${TMP_DIR}/repo)
-endforeach()
 execute_process(
     COMMAND ${GIT} describe --dirty --long --always --match [0-9]*
     WORKING_DIRECTORY ${TMP_DIR}/repo
@@ -24,9 +19,9 @@ execute_process(
     WORKING_DIRECTORY ${TMP_DIR}/repo
     OUTPUT_VARIABLE REVS
     RESULT_VARIABLE RESULT)
-string(STRIP "${REVS}" REVS)
-string(REPLACE "\n" ";" REVS "${REVS}")
+separate_arguments(REVS UNIX_COMMAND "${REVS}")
 list(GET REVS 10 PARENT)
+string(STRIP "${REVS}" REVS)
 message("PARENT: ${PARENT}")
 write_version_cmake(
     ${TMP_DIR}/repo


### PR DESCRIPTION
## Motivation

- Solidify Action versioning and add Dependabot scanning to keep up to date

## Technical Details

- Pin versions of actions used to commit SHAs instead of mutable version tags
- Add github-actions to dependabot.yml
- Replace cancel action with native GitHub concurrency block

## Test Plan

Validate actions functionality on PR after merge